### PR TITLE
Removes security summary from CLI output

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -129,6 +129,11 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 # Install Wrangler CLI globally
 RUN npm install -g wrangler@latest
 
+# Install Fly CLI
+RUN curl -L https://fly.io/install.sh | sh \
+    && mv /root/.fly/bin/flyctl /usr/local/bin/fly \
+    && chmod +x /usr/local/bin/fly
+
 # Set up Git configuration for development
 RUN git config --global init.defaultBranch main \
     && git config --global advice.detachedHead false

--- a/compiler/cmd/osprey/main.go
+++ b/compiler/cmd/osprey/main.go
@@ -186,9 +186,6 @@ func main() {
 	if security != nil && (security.SandboxMode || !security.AllowHTTP || !security.AllowWebSocket ||
 		!security.AllowFileRead || !security.AllowFileWrite || !security.AllowFFI) {
 
-		// Show security summary
-		fmt.Println(security.GetSecuritySummary())
-
 		// Use security-aware command execution
 		result = cli.RunCommandWithSecurity(filename, outputMode, security)
 	} else {

--- a/compiler/internal/cli/cli.go
+++ b/compiler/internal/cli/cli.go
@@ -256,7 +256,7 @@ func runRunProgram(source string) CommandResult {
 	}
 
 	return CommandResult{
-		Output:  "Running program...\n",
+		Output:  "",
 		Success: true,
 	}
 }
@@ -1101,7 +1101,7 @@ func runRunProgramWithSecurity(source string, security *SecurityConfig) CommandR
 	}
 
 	return CommandResult{
-		Output:  "Running program...\n",
+		Output:  "",
 		Success: true,
 	}
 }

--- a/compiler/tests/integration/cli_test.go
+++ b/compiler/tests/integration/cli_test.go
@@ -332,11 +332,8 @@ print(serverID)`
 		t.Errorf("Expected sandbox mode to block HTTP functions, but compilation succeeded\nOutput: %s", string(output))
 	}
 
-	// Check for security summary and proper error
+	// Check for proper error (security summary removed from CLI output)
 	outputStr := string(output)
-	if !strings.Contains(outputStr, "SANDBOX MODE") {
-		t.Error("Expected security summary with SANDBOX MODE")
-	}
 	if !strings.Contains(outputStr, "unsupported call expression") {
 		t.Error("Expected 'unsupported call expression' error for blocked function")
 	}
@@ -360,11 +357,7 @@ print(clientID)`
 		t.Errorf("Expected --no-http to block HTTP functions, but compilation succeeded\nOutput: %s", string(output))
 	}
 
-	// Check for security summary
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "Unavailable=[HTTP]") {
-		t.Error("Expected security summary showing HTTP unavailable")
-	}
+	// Security summary removed from CLI output - test still validates blocking works
 }
 
 func testNoWebSocketBlocksWebSocket(t *testing.T) {
@@ -386,11 +379,7 @@ print(wsID)`
 			"Output: %s", string(output))
 	}
 
-	// Check for security summary
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "Unavailable=[WebSocket]") {
-		t.Error("Expected security summary showing WebSocket unavailable")
-	}
+	// Security summary removed from CLI output - test still validates blocking works
 }
 
 func testMultipleSecurityFlags(t *testing.T) {
@@ -412,11 +401,7 @@ print(x + y)`
 		t.Errorf("Safe code should compile with security restrictions: %v\nOutput: %s", err, string(output))
 	}
 
-	// Check for security summary
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "Unavailable=[HTTP,WebSocket,FFI]") {
-		t.Error("Expected security summary showing multiple restrictions")
-	}
+	// Security summary removed from CLI output - test still validates restrictions work
 }
 
 func testSafeCodeInSandbox(t *testing.T) {
@@ -440,11 +425,8 @@ print(x + y)`
 		t.Errorf("Safe code should compile in sandbox mode: %v\nOutput: %s", err, string(output))
 	}
 
-	// Check for security summary and LLVM output
+	// Check for LLVM output (security summary removed from CLI)
 	outputStr := string(output)
-	if !strings.Contains(outputStr, "SANDBOX MODE") {
-		t.Error("Expected security summary with SANDBOX MODE")
-	}
 	if !strings.Contains(outputStr, "define") || !strings.Contains(outputStr, "@main") {
 		t.Error("Expected valid LLVM IR output for safe code")
 	}
@@ -467,9 +449,5 @@ func testSecurityFlagCombinations(t *testing.T) {
 		t.Errorf("Safe code should work with --no-fs: %v\nOutput: %s", err, string(output))
 	}
 
-	// Check for security summary
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "FileRead") || !strings.Contains(outputStr, "FileWrite") {
-		t.Error("Expected security summary showing file system restrictions")
-	}
+	// Security summary removed from CLI output - test still validates flag works
 }

--- a/webcompiler/fly.toml
+++ b/webcompiler/fly.toml
@@ -1,27 +1,32 @@
-app = "osprey-webcompiler"
-primary_region = "ord"
+# fly.toml app configuration file generated for osprey-webcompiler on 2025-06-18T09:26:02Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'osprey-webcompiler'
+primary_region = 'ord'
 
 [build]
 
 [env]
-NODE_ENV = "production"
-DOCKER_ENV = "true"
+  DOCKER_ENV = 'true'
+  NODE_ENV = 'production'
 
 [http_service]
-internal_port = 3001
-force_https = true
-auto_stop_machines = true
-auto_start_machines = true
-min_machines_running = 0
+  internal_port = 3001
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = 'requests'
+    hard_limit = 30
+    soft_limit = 25
+
+  [http_service.http_options]
+    idle_timeout = 5
 
 [[vm]]
-size = "shared-cpu-1x"
-memory = "256mb"
-
-[http_service.concurrency]
-type = "requests"
-hard_limit = 30
-soft_limit = 25
-
-[http_service.http_options]
-idle_timeout = "5s" 
+  size = 'shared-cpu-1x'
+  memory = '256mb'


### PR DESCRIPTION
# TLDR
Cleans up CLI output by removing redundant security summary.

# What Was Added?
N/A

# What Was Changed / Deleted?
- Removes the `fmt.Println(security.GetSecuritySummary())` call from `main.go`.
- Removes the initial "Running program..." output in CLI command results.
- Removes tests that check for security summary in CLI output.
- Updates `fly.toml` for webcompiler to latest format from `flyctl launch`.

# How Do The Automated Tests Prove It Works?
Tests validate that security restrictions are still enforced correctly, even without the summary being printed.

# Summarise Changes To The Spec Here
N/A