### PR TITLE
Updates playground API URL

### DIFF
--- a/website/src/playground/index.md
+++ b/website/src/playground/index.md
@@ -326,7 +326,7 @@ description: "Try Osprey programming language online with interactive code examp
 
 <script>
     let editor;
-    const API_URL = 'https://osprey-web-compiler-gateway.mail-bff.workers.dev/api';
+    const API_URL = 'https://osprey.fly.dev/api';
     
     // Initialize Monaco Editor
     require.config({ paths: { vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.45.0/min/vs' } });


### PR DESCRIPTION
# TLDR
Updates the playground to use the new Osprey API URL.

# What Was Added?
Nothing.

# What Was Changed / Deleted?
The playground's API URL has been updated from `https://osprey-web-compiler-gateway.mail-bff.workers.dev/api` to `https://osprey.fly.dev/api`. The old URL is no longer valid.

# How Do The Automated Tests Prove It Works?

# Summarise Changes To The Spec Here
