### PR TITLE
Adds ospreylang.dev to CORS allowed origins

### DIFF
--- a/webcompiler/src/server.js
+++ b/webcompiler/src/server.js
@@ -27,7 +27,9 @@ app.use((req, res, next) => {
         'http://localhost:8080',
         'http://127.0.0.1:8080',
         'http://localhost:3001',
-        'http://127.0.0.1:3001'
+        'http://127.0.0.1:3001',
+        'https://ospreylang.dev',
+        'https://www.ospreylang.dev'
     ];
 
     if (allowedOrigins.includes(origin)) {
@@ -173,7 +175,9 @@ const wss = new WebSocketServer({
             'http://localhost:8080',
             'http://127.0.0.1:8080',
             'http://localhost:3001',
-            'http://127.0.0.1:3001'
+            'http://127.0.0.1:3001',
+            'https://ospreylang.dev',
+            'https://www.ospreylang.dev'
         ];
 
         console.log('🔍 WebSocket upgrade request from origin:', origin);


### PR DESCRIPTION
# TLDR
Adds the ospreylang.dev domains to the list of allowed origins for CORS.

# What Was Added?
Adds `https://ospreylang.dev` and `https://www.ospreylang.dev` to the allowed origins for both the main app and the WebSocket server.

# What Was Changed / Deleted?
The allowed origins list in `server.js` has been updated.

# How Do The Automated Tests Prove It Works?
N/A

# Summarise Changes To The Spec Here
N/A 