### PR TITLE
Removes Light Mode Support and Enforces Dark Mode

### DIFF
--- a/website/src/css/components.css
+++ b/website/src/css/components.css
@@ -1171,29 +1171,23 @@ p:has(.cta-actions) {
   border-bottom: none;
 }
 
-.comparison-table tbody tr:hover {
-  background: var(--color-primary-50);
-  transition: background-color var(--transition-fast);
+.comparison-table {
+  background: var(--color-bg-secondary);
+  border-color: var(--color-neutral-600);
 }
 
-@media (prefers-color-scheme: dark) {
-  .comparison-table {
-    background: var(--color-bg-secondary);
-    border-color: var(--color-neutral-600);
-  }
+.comparison-table th {
+  background: var(--color-bg-tertiary);
+}
 
-  .comparison-table th {
-    background: var(--color-bg-tertiary);
-  }
+.comparison-table th:first-child,
+.comparison-table td:last-child {
+  color: var(--color-primary-300);
+}
 
-  .comparison-table th:first-child,
-  .comparison-table td:last-child {
-    color: var(--color-primary-300);
-  }
-
-  .comparison-table tbody tr:hover {
-    background: var(--color-neutral-700);
-  }
+.comparison-table tbody tr:hover {
+  background: var(--color-neutral-700);
+  transition: background-color var(--transition-fast);
 }
 
 /* Header Anchor Links */

--- a/website/src/css/variables.css
+++ b/website/src/css/variables.css
@@ -1,44 +1,57 @@
 :root {
   /* Design System Color Palette - Osprey Brand Colors */
-  
+
   /* Primary Blues - From Design System */
   --color-primary-50: #F0F8FF;
-  --color-primary-100: #C7EBF9;  /* Sky */
-  --color-primary-200: #77D7F4;  /* Aqua */
-  --color-primary-300: #38A1DB;  /* BlueLight */
+  --color-primary-100: #C7EBF9;
+  /* Sky */
+  --color-primary-200: #77D7F4;
+  /* Aqua */
+  --color-primary-300: #38A1DB;
+  /* BlueLight */
   --color-primary-400: #2B8BC7;
-  --color-primary-500: #005C9C;  /* BlueMid */
-  --color-primary-600: #005C9C;  /* BlueMid - Main brand color */
+  --color-primary-500: #005C9C;
+  /* BlueMid */
+  --color-primary-600: #005C9C;
+  /* BlueMid - Main brand color */
   --color-primary-700: #004A7F;
   --color-primary-800: #003862;
-  --color-primary-900: #0B3A5E;  /* BlueDark */
-  
+  --color-primary-900: #0B3A5E;
+  /* BlueDark */
+
   /* Design System Gradient Colors */
   --gradient-primary: linear-gradient(135deg, #005C9C 0%, #0B3A5E 100%);
   --gradient-secondary: linear-gradient(135deg, #38A1DB 0%, #77D7F4 100%);
   --gradient-accent: linear-gradient(135deg, #77D7F4 0%, #C7EBF9 100%);
   --gradient-hero: linear-gradient(135deg, #005C9C 0%, #0B3A5E 50%, #38A1DB 100%);
   --gradient-dark: linear-gradient(135deg, #0B3A5E 0%, #1F1F1F 50%, #000000 100%);
-  
-  /* Glass Morphism - Updated for brand colors */
-  --glass-bg: rgba(255, 255, 255, 0.1);
-  --glass-border: rgba(0, 92, 156, 0.2);  /* BlueMid with transparency */
-  --glass-shadow: 0 8px 32px 0 rgba(11, 58, 94, 0.37);  /* BlueDark with transparency */
+
+  /* Glass Morphism - Always Dark Mode */
+  --glass-bg: rgba(11, 58, 94, 0.2);
+  --glass-border: rgba(119, 215, 244, 0.1);
+  /* Aqua with transparency */
+  --glass-shadow: 0 8px 32px 0 rgba(11, 58, 94, 0.37);
+  /* BlueDark with transparency */
   --glass-blur: blur(10px);
-  
+
   /* Enhanced Shadows - Using brand colors */
   --shadow-sm: 0 2px 4px rgba(11, 58, 94, 0.05);
   --shadow-md: 0 4px 12px rgba(11, 58, 94, 0.08);
   --shadow-lg: 0 8px 24px rgba(11, 58, 94, 0.12);
   --shadow-xl: 0 16px 48px rgba(11, 58, 94, 0.16);
   --shadow-2xl: 0 24px 64px rgba(11, 58, 94, 0.2);
-  --shadow-glow: 0 0 40px rgba(0, 92, 156, 0.5);  /* BlueMid glow */
-  --shadow-neon: 0 0 80px rgba(56, 161, 219, 0.8);  /* BlueLight neon */
-  
+  --shadow-glow: 0 0 40px rgba(0, 92, 156, 0.5);
+  /* BlueMid glow */
+  --shadow-neon: 0 0 80px rgba(56, 161, 219, 0.8);
+  /* BlueLight neon */
+
   /* Design System Neutral Colors */
-  --color-neutral-0: #FFFFFF;     /* White */
-  --color-neutral-50: #FDFDFD;    /* OffWhite */
-  --color-neutral-100: #F2F2F2;   /* LightGrey */
+  --color-neutral-0: #FFFFFF;
+  /* White */
+  --color-neutral-50: #FDFDFD;
+  /* OffWhite */
+  --color-neutral-100: #F2F2F2;
+  /* LightGrey */
   --color-neutral-200: #E8E8E8;
   --color-neutral-300: #D4D4D4;
   --color-neutral-400: #A3A3A3;
@@ -46,43 +59,53 @@
   --color-neutral-600: #525252;
   --color-neutral-700: #404040;
   --color-neutral-800: #262626;
-  --color-neutral-900: #1F1F1F;   /* DarkGrey */
+  --color-neutral-900: #1F1F1F;
+  /* DarkGrey */
   --color-neutral-950: #0a0a0a;
-  
+
   /* Accent Colors - Harmonized with design system */
   --color-accent-purple: #8b5cf6;
   --color-accent-pink: #ec4899;
-  --color-accent-blue: #38A1DB;   /* BlueLight */
-  --color-accent-teal: #77D7F4;   /* Aqua */
+  --color-accent-blue: #38A1DB;
+  /* BlueLight */
+  --color-accent-teal: #77D7F4;
+  /* Aqua */
   --color-accent-orange: #f97316;
-  
-  /* Background Colors - Using design system colors */
-  --color-bg-primary: #FDFDFD;    /* OffWhite */
-  --color-bg-secondary: #F2F2F2;  /* LightGrey */
-  --color-bg-tertiary: #FFFFFF;   /* White */
-  --color-bg-dark: #1F1F1F;       /* DarkGrey */
-  
-  /* Text Colors - Using design system colors */
-  --color-text-primary: #1F1F1F;  /* DarkGrey */
-  --color-text-secondary: #0B3A5E; /* BlueDark */
-  --color-text-tertiary: #525252;
-  --color-text-inverse: #FDFDFD;  /* OffWhite */
-  
-  /* Border Colors - From Design System */
-  --color-border-light: #E8E8E8;
-  --color-border-medium: #D4D4D4;
-  --color-border-primary: #005C9C;  /* BlueMid */
-  
+
+  /* Background Colors - Always Dark Mode */
+  --color-bg-primary: #1F1F1F;
+  /* DarkGrey */
+  --color-bg-secondary: #262626;
+  --color-bg-tertiary: #404040;
+  --color-bg-dark: #1F1F1F;
+  /* DarkGrey */
+
+  /* Text Colors - Always Dark Mode */
+  --color-text-primary: #FDFDFD;
+  /* OffWhite */
+  --color-text-secondary: #F2F2F2;
+  /* LightGrey */
+  --color-text-tertiary: #A3A3A3;
+  --color-text-inverse: #1F1F1F;
+  /* DarkGrey */
+
+  /* Border Colors - Always Dark Mode */
+  --color-border-light: #404040;
+  --color-border-medium: #525252;
+  --color-border-primary: #005C9C;
+  /* BlueMid */
+
   /* State Colors - Built from design system */
   --color-success: #10b981;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
-  --color-info: #38A1DB;  /* BlueLight */
-  
+  --color-info: #38A1DB;
+  /* BlueLight */
+
   /* Typography with modern fonts */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   --font-mono: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Inconsolata', monospace;
-  
+
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-base: 1rem;
@@ -95,17 +118,17 @@
   --font-size-6xl: 3.75rem;
   --font-size-7xl: 4.5rem;
   --font-size-8xl: 6rem;
-  
+
   --font-weight-normal: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   --font-weight-extrabold: 800;
-  
+
   --line-height-tight: 1.25;
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.75;
-  
+
   /* Spacing */
   --space-0: 0;
   --space-1: 0.25rem;
@@ -125,7 +148,7 @@
   --space-48: 12rem;
   --space-56: 14rem;
   --space-64: 16rem;
-  
+
   /* Border Radius */
   --radius-sm: 0.25rem;
   --radius-md: 0.5rem;
@@ -134,14 +157,14 @@
   --radius-2xl: 1.5rem;
   --radius-3xl: 2rem;
   --radius-full: 9999px;
-  
+
   /* Transitions */
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
   --transition-slow: 350ms ease;
   --transition-spring: 500ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
   --transition-bounce: 600ms cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  
+
   /* Z-index scale */
   --z-negative: -1;
   --z-0: 0;
@@ -155,43 +178,29 @@
   --z-80: 80;
   --z-90: 90;
   --z-100: 100;
-  
+
   /* Container widths */
   --container-sm: 640px;
   --container-md: 768px;
   --container-lg: 1024px;
   --container-xl: 1280px;
   --container-2xl: 1536px;
-  
+
   /* Animation Timing Functions */
   --ease-in-out-expo: cubic-bezier(0.87, 0, 0.13, 1);
   --ease-in-out-circ: cubic-bezier(0.85, 0, 0.15, 1);
   --ease-out-back: cubic-bezier(0.34, 1.56, 0.64, 1);
   --ease-in-out-back: cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  
+
   /* Backdrop Filters */
   --backdrop-blur-sm: blur(4px);
   --backdrop-blur-md: blur(8px);
   --backdrop-blur-lg: blur(16px);
   --backdrop-blur-xl: blur(24px);
-}
 
-/* Dark mode variables - Updated for design system */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg-primary: #1F1F1F;
-    --color-bg-secondary: #262626;
-    --color-bg-tertiary: #404040;
-    --color-text-primary: #FDFDFD;
-    --color-text-secondary: #F2F2F2;   /* LightGrey */
-    --color-text-secondary: #F2F2F2;
-    --color-text-tertiary: #A3A3A3;
-    --glass-bg: rgba(11, 58, 94, 0.2);
-    --glass-border: rgba(119, 215, 244, 0.1); /* Aqua with transparency */
-    --glass-border: rgba(119, 215, 244, 0.1);
-    --nav-bg-default: rgba(11, 58, 94, 1.0);
-    --nav-bg-scrolled: rgba(11, 58, 94, 1.0);
-    --nav-border-default: rgba(119, 215, 244, 0.6);
-    --nav-border-scrolled: rgba(119, 215, 244, 0.7);
-  }
+  /* Navigation Colors - Always Dark Mode */
+  --nav-bg-default: rgba(11, 58, 94, 1.0);
+  --nav-bg-scrolled: rgba(11, 58, 94, 1.0);
+  --nav-border-default: rgba(119, 215, 244, 0.6);
+  --nav-border-scrolled: rgba(119, 215, 244, 0.7);
 }


### PR DESCRIPTION
# TLDR
Fixes white on white background issues. #14. Removes the light mode color scheme and enforces a consistent dark mode appearance across the website.

# What Was Added?
- Consistent dark mode color scheme.

# What Was Changed / Deleted?
- Removed light mode color variables and media query.
- Modified `comparison-table` styling to align with dark mode.
- Updated glass morphism and other color-related variables for a dark mode aesthetic.

# How Do The Automated Tests Prove It Works?

# Summarise Changes To The Spec Here