### PR TITLE
Enhances Error Handling and Output In Web Playground

### DIFF
--- a/compiler/internal/cli/cli.go
+++ b/compiler/internal/cli/cli.go
@@ -248,18 +248,20 @@ func runCompileToExecutable(source, filename string) CommandResult {
 }
 
 func runRunProgram(source string) CommandResult {
-	// Notify running program (for test expectations)
-	preMessage := "Running program...\n"
+	fmt.Fprintf(os.Stderr, "Starting compilation...\n")
 
 	if err := codegen.CompileAndRun(source); err != nil {
+		fmt.Fprintf(os.Stderr, "Compilation failed\n")
 		return CommandResult{
 			Success:  false,
 			ErrorMsg: fmt.Sprintf("Execution failed: %v", err),
 		}
 	}
 
+	fmt.Fprintf(os.Stderr, "Compilation completed successfully\n")
+
 	return CommandResult{
-		Output:  preMessage + "Program executed successfully\n",
+		Output:  "",
 		Success: true,
 	}
 }
@@ -1093,21 +1095,23 @@ func runCompileToExecutableWithSecurity(source, filename string, security *Secur
 }
 
 func runRunProgramWithSecurity(source string, security *SecurityConfig) CommandResult {
-	// Notify running program (for test expectations)
-	preMessage := "Running program...\n"
+	fmt.Fprintf(os.Stderr, "Starting compilation...\n")
 
 	// Convert CLI security config to codegen security config
 	codegenSecurity := convertToCodegenSecurity(security)
 
 	if err := codegen.CompileAndRunWithSecurity(source, codegenSecurity); err != nil {
+		fmt.Fprintf(os.Stderr, "Compilation failed\n")
 		return CommandResult{
 			Success:  false,
 			ErrorMsg: fmt.Sprintf("Execution failed: %v", err),
 		}
 	}
 
+	fmt.Fprintf(os.Stderr, "Compilation completed successfully\n")
+
 	return CommandResult{
-		Output:  preMessage + "Program executed successfully\n",
+		Output:  "",
 		Success: true,
 	}
 }

--- a/compiler/tests/unit/cli_test.go
+++ b/compiler/tests/unit/cli_test.go
@@ -97,8 +97,9 @@ func TestRunCommand_Run(t *testing.T) {
 		t.Fatalf("Expected success, got error: %s", result.ErrorMsg)
 	}
 
-	if !strings.Contains(result.Output, "Running program") {
-		t.Errorf("Expected run output, got: %s", result.Output)
+	// The output should be empty for successful runs (just the program output)
+	if result.Output != "" {
+		t.Errorf("Expected empty output for successful run, got: %s", result.Output)
 	}
 }
 
@@ -167,8 +168,15 @@ func TestRunCommand_AllModes(t *testing.T) {
 				t.Fatalf("Mode %s failed: %s", mode, result.ErrorMsg)
 			}
 
-			if result.Output == "" {
-				t.Errorf("Mode %s produced no output", mode)
+			// Run mode returns empty output (program output only), other modes should have output
+			if mode == cli.OutputModeRun {
+				if result.Output != "" {
+					t.Errorf("Mode %s should produce empty output, got: %s", mode, result.Output)
+				}
+			} else {
+				if result.Output == "" {
+					t.Errorf("Mode %s produced no output", mode)
+				}
 			}
 		})
 	}

--- a/webcompiler/.cursor/rules/production-api.mdc
+++ b/webcompiler/.cursor/rules/production-api.mdc
@@ -1,10 +1,12 @@
 ---
-description:
-globs:
+description: 
+globs: 
 alwaysApply: false
 ---
 # Production API Rules
 
+- **SECURITY FIRST** - We don't want this thing running up a huge bill so check every line for DOS attacks
+- **MUST RETURN TWO OUTPUTS OR ERROR OUTPUT** - The main API returns 1. Compiler output 2. App output, and these must be distinct in the JSON response
 - **PRODUCTION API** - Don't break it, keep changes minimal and safe
 - **SERVES LSP FOR WEBSITE** - This API must stay working for language server
 - **DOCKER COMPOSE MUST WORK** - Build and run successfully for deployment

--- a/webcompiler/src/server.js
+++ b/webcompiler/src/server.js
@@ -69,7 +69,11 @@ app.post('/api/compile', async (req, res) => {
     try {
         const result = await runOspreyCompiler(['--sandbox', '--ast'], code)
         console.log('✅ Compile success, output length:', result.stdout.length)
-        res.json({ success: true, output: result.stdout })
+        res.json({
+            success: true,
+            compilerOutput: result.stderr || '',
+            programOutput: result.stdout || '' // AST output goes to stdout
+        })
     } catch (error) {
         console.error('❌ Compile error:', error.message)
         res.status(500).json({ success: false, error: error.message })
@@ -88,8 +92,15 @@ app.post('/api/run', async (req, res) => {
 
     try {
         const result = await runOspreyCompiler(['--sandbox', '--run'], code)
-        console.log('✅ Run success, output length:', result.stdout.length)
-        res.json({ success: true, output: result.stdout })
+        console.log('✅ Run success')
+        console.log('📊 Compiler output length:', result.stderr?.length || 0)
+        console.log('📋 Program output length:', result.stdout?.length || 0)
+
+        res.json({
+            success: true,
+            compilerOutput: result.stderr || '',
+            programOutput: result.stdout || ''
+        })
     } catch (error) {
         console.error('❌ Run error:', error.message)
         res.status(500).json({ success: false, error: error.message })

--- a/webcompiler/src/server.js
+++ b/webcompiler/src/server.js
@@ -159,7 +159,7 @@ function runOspreyCompiler(args, code = '') {
             // Use the osprey binary from PATH (installed in Docker) or fallback to local dev path
             const ospreyPath = process.env.NODE_ENV === 'production' || process.env.DOCKER_ENV
                 ? 'osprey'
-                : path.resolve(__dirname, '../../compiler/bin/osprey')
+                : path.resolve(__dirname, '../compiler/bin/osprey')
             console.log(`🔨 Running: ${ospreyPath} ${tempFile} ${args.join(' ')}`)
             const child = spawn(ospreyPath, [tempFile, ...args], {
                 stdio: 'pipe',

--- a/webcompiler/src/server.js
+++ b/webcompiler/src/server.js
@@ -68,14 +68,25 @@ app.post('/api/compile', async (req, res) => {
 
     try {
         const result = await runOspreyCompiler(['--sandbox', '--ast'], code)
-        console.log('✅ Compile success, output length:', result.stdout.length)
-        res.json({
-            success: true,
-            compilerOutput: result.stderr || '',
-            programOutput: result.stdout || '' // AST output goes to stdout
-        })
+
+        if (result.success) {
+            console.log('✅ Compile success, output length:', result.stdout.length)
+            res.status(200).json({
+                success: true,
+                compilerOutput: result.stderr || '',
+                programOutput: result.stdout || '' // AST output goes to stdout
+            })
+        } else {
+            console.error('❌ Compile error, stderr:', result.stderr)
+            res.status(422).json({ // 422 Unprocessable Entity for compilation errors
+                success: false,
+                compilerOutput: result.stderr || '',
+                programOutput: result.stdout || '',
+                error: result.stderr || result.stdout || `Compilation failed with exit code ${result.exitCode}`
+            })
+        }
     } catch (error) {
-        console.error('❌ Compile error:', error.message)
+        console.error('❌ System error:', error.message)
         res.status(500).json({ success: false, error: error.message })
     }
 })
@@ -92,17 +103,40 @@ app.post('/api/run', async (req, res) => {
 
     try {
         const result = await runOspreyCompiler(['--sandbox', '--run'], code)
-        console.log('✅ Run success')
-        console.log('📊 Compiler output length:', result.stderr?.length || 0)
-        console.log('📋 Program output length:', result.stdout?.length || 0)
 
-        res.json({
-            success: true,
-            compilerOutput: result.stderr || '',
-            programOutput: result.stdout || ''
-        })
+        if (result.success) {
+            console.log('✅ Run success')
+            console.log('📊 Compiler output length:', result.stderr?.length || 0)
+            console.log('📋 Program output length:', result.stdout?.length || 0)
+
+            res.status(200).json({
+                success: true,
+                compilerOutput: result.stderr || '',
+                programOutput: result.stdout || ''
+            })
+        } else {
+            console.error('❌ Run failed, stderr:', result.stderr)
+            console.error('❌ Run failed, stdout:', result.stdout)
+
+            // Determine if it's a compilation error or runtime error
+            const errorOutput = result.stderr || result.stdout || '';
+            const isCompilationError = errorOutput.includes('parse errors') ||
+                errorOutput.includes('failed to generate') ||
+                errorOutput.includes('undefined variable') ||
+                errorOutput.includes('syntax error');
+
+            const statusCode = isCompilationError ? 422 : 400; // 422 for compilation, 400 for runtime
+
+            res.status(statusCode).json({
+                success: false,
+                compilerOutput: result.stderr || '',
+                programOutput: result.stdout || '',
+                isCompilationError: isCompilationError,
+                error: errorOutput || `Process failed with exit code ${result.exitCode}`
+            })
+        }
     } catch (error) {
-        console.error('❌ Run error:', error.message)
+        console.error('❌ System error:', error.message)
         res.status(500).json({ success: false, error: error.message })
     }
 })
@@ -144,7 +178,7 @@ function runOspreyCompiler(args, code = '') {
                 stderr += data.toString()
             })
 
-            child.on('close', async (code) => {
+            child.on('close', async (exitCode) => {
                 // Clean up temp file
                 try {
                     await fs.unlink(tempFile)
@@ -153,11 +187,13 @@ function runOspreyCompiler(args, code = '') {
                     console.error('⚠️ Failed to clean up temp file:', e.message)
                 }
 
-                if (code === 0) {
-                    resolve({ stdout, stderr })
-                } else {
-                    reject(new Error(stderr || stdout || `Process exited with code ${code}`))
-                }
+                // Always resolve with the result - let the caller determine success/failure
+                resolve({
+                    exitCode,
+                    stdout,
+                    stderr,
+                    success: exitCode === 0
+                })
             })
 
             child.on('error', async (error) => {

--- a/website/src/playground/index.md
+++ b/website/src/playground/index.md
@@ -573,11 +573,14 @@ print("Demo complete!")`,
                 // Handle HTTP errors that still have JSON error details
                 if (result.error) {
                     output.className = 'error';
+                    const errorLabel = result.isCompilationError ? 'Compilation Error' : 'Execution Error';
+                    const statusMessage = result.isCompilationError ? 'Compilation failed' : 'Execution failed';
+                    
                     output.innerHTML = `<div class="output-section">
-                        <div class="output-label">Execution Error</div>
+                        <div class="output-label">${errorLabel}</div>
                         <div class="compiler-output">${formatOutput(result.error)}</div>
                     </div>`;
-                    updateStatus('error', 'Execution failed');
+                    updateStatus('error', statusMessage);
                     return;
                 } else {
                     throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -636,10 +639,11 @@ print("Demo complete!")`,
         // Escape HTML
         text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         
-        // Highlight line numbers (format: "line X:Y" or "at line X")
-        text = text.replace(/(\b(?:line|Line)\s+)(\d+)([:\s])/g, '$1<span class="line-number">$2</span>$3');
-        text = text.replace(/(\bat line\s+)(\d+)/g, '$1<span class="line-number">$2</span>');
-        text = text.replace(/(\berror at\s+)(\d+)([:\s])/g, '$1<span class="line-number">$2</span>$3');
+        // Highlight line numbers - more comprehensive patterns
+        text = text.replace(/(\bline\s+)(\d+)(\s*:\s*\d+)?/gi, '$1<span class="line-number">$2$3</span>');
+        text = text.replace(/(\bat line\s+)(\d+)/gi, '$1<span class="line-number">$2</span>');
+        text = text.replace(/(\berror at\s+)(\d+)/gi, '$1<span class="line-number">$2</span>');
+        text = text.replace(/(\[)(\d+)(\s*:\s*\d+)(\])/g, '$1<span class="line-number">$2$3</span>$4');
         
         return text;
     }

--- a/website/src/playground/index.md
+++ b/website/src/playground/index.md
@@ -447,7 +447,7 @@ description: "Try Osprey programming language online with interactive code examp
 
 <script>
     let editor;
-    const API_URL = 'http://localhost:3001';
+    const API_URL = 'https://osprey.fly.dev/api';
     
     // Initialize Monaco Editor
     require.config({ paths: { vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.45.0/min/vs' } });

--- a/website/src/playground/index.md
+++ b/website/src/playground/index.md
@@ -82,7 +82,7 @@ description: "Try Osprey programming language online with interactive code examp
     }
     
     .status-dot.connected {
-        background: #4ec9b0;
+        background: #5a8a6b;
     }
     
     .status-dot.error {
@@ -131,15 +131,15 @@ description: "Try Osprey programming language online with interactive code examp
     }
     
     #output.error {
-        color: #f44747;
-        background: #2d1b1b;
-        border-left: 3px solid #f44747;
+        color: #d4d4d4;
+        background: #1e1e1e;
+        border-left: none;
     }
     
     #output.success {
-        color: #4ec9b0;
-        background: #1b2d1b;
-        border-left: 3px solid #4ec9b0;
+        color: #d4d4d4;
+        background: #1e1e1e;
+        border-left: none;
     }
     
     #output.warning {
@@ -166,20 +166,19 @@ description: "Try Osprey programming language online with interactive code examp
     }
     
     .compiler-output {
-        color: #f44747;
-        background: rgba(244, 71, 71, 0.1);
-        padding: 12px;
-        border-radius: 4px;
-        border-left: 3px solid #f44747;
+        color: #d4d4d4;
+        background: transparent;
+        padding: 0;
+        border: none;
         margin-bottom: 12px;
     }
     
     .program-output {
-        color: #4ec9b0;
-        background: rgba(78, 201, 176, 0.1);
+        color: #7cb992;
+        background: rgba(124, 185, 146, 0.08);
         padding: 12px;
         border-radius: 4px;
-        border-left: 3px solid #4ec9b0;
+        border-left: 3px solid #5a8a6b;
     }
     
     .program-output.empty {
@@ -189,6 +188,68 @@ description: "Try Osprey programming language online with interactive code examp
     .line-number {
         color: #569cd6;
         font-weight: bold;
+    }
+    
+    /* Error listview styles */
+    .error-list {
+        display: grid;
+        gap: 1px;
+        font-family: 'Consolas', 'Monaco', monospace;
+        font-size: 13px;
+        line-height: 1.4;
+    }
+    
+    .error-line {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 12px;
+        padding: 8px 12px;
+        background: #2d2d30;
+        border: 1px solid #444;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        align-items: center;
+    }
+    
+    .error-line:hover {
+        background: #3c3c3c;
+        border-color: #569cd6;
+    }
+    
+    .error-line.selected {
+        background: #404040;
+        border-color: #569cd6;
+        box-shadow: 0 0 0 1px #569cd6;
+    }
+    
+    .error-location {
+        color: #569cd6;
+        font-weight: bold;
+        font-size: 12px;
+        white-space: nowrap;
+        cursor: pointer;
+        text-decoration: none;
+    }
+    
+    .error-location:hover {
+        text-decoration: underline;
+    }
+    
+    .error-message {
+        color: #f44747;
+        flex: 1;
+        word-break: break-word;
+    }
+    
+    /* Editor error highlighting */
+    .highlighted-error-line {
+        background: rgba(244, 71, 71, 0.15) !important;
+        border-left: 2px solid #f44747 !important;
+    }
+    
+    .error-glyph {
+        background: #f44747;
+        width: 4px !important;
     }
     
     /* Splitter styles */
@@ -456,9 +517,7 @@ print("Math: \${a} * \${b} = \${product}")
 
 // Range iteration
 print("Numbers 1-5:")
-range(1, 6) |> forEach(print)
-
-print("Demo complete!")`,
+range(1, 6) |> forEach(print)`,
             language: 'osprey',
             theme: 'vs-dark',
             automaticLayout: true
@@ -496,10 +555,7 @@ print("Demo complete!")`,
                 // Handle HTTP errors that still have JSON error details
                 if (result.error) {
                     output.className = 'error';
-                    output.innerHTML = `<div class="output-section">
-                        <div class="output-label">Compilation Error</div>
-                        <div class="compiler-output">${formatOutput(result.error)}</div>
-                    </div>`;
+                    output.innerHTML = formatErrorOutput(result.error);
                     updateStatus('error', 'Compilation failed');
                     return;
                 } else {
@@ -510,45 +566,26 @@ print("Demo complete!")`,
             if (result.success) {
                 // Successful compilation
                 output.className = 'success';
-                let outputHtml = '';
-                
-                if (result.compilerOutput && result.compilerOutput.trim()) {
-                    outputHtml += `<div class="output-section">
-                        <div class="output-label">Compiler Messages</div>
-                        <div class="compiler-output">${formatOutput(result.compilerOutput)}</div>
-                    </div>`;
-                }
+                let outputText = '';
                 
                 if (result.programOutput && result.programOutput.trim()) {
-                    outputHtml += `<div class="output-section">
-                        <div class="output-label">AST Output</div>
-                        <div class="program-output">${formatOutput(result.programOutput)}</div>
-                    </div>`;
+                    outputText = formatPlainOutput(result.programOutput);
                 } else {
-                    outputHtml += `<div class="output-section">
-                        <div class="output-label">AST Output</div>
-                        <div class="program-output">✅ Compilation successful - no output</div>
-                    </div>`;
+                    outputText = '✅ Compilation successful - no output';
                 }
                 
-                output.innerHTML = outputHtml;
+                output.innerHTML = outputText;
                 updateStatus('connected', 'Ready');
             } else {
                 // Compilation failed
                 output.className = 'error';
-                output.innerHTML = `<div class="output-section">
-                    <div class="output-label">Compilation Error</div>
-                    <div class="compiler-output">${formatOutput(result.error)}</div>
-                </div>`;
+                output.innerHTML = formatErrorOutput(result.error || 'Unknown compilation error');
                 updateStatus('error', 'Compilation failed');
             }
             
         } catch (error) {
             output.className = 'error';
-            output.innerHTML = `<div class="output-section">
-                <div class="output-label">Network Error</div>
-                <div class="compiler-output">Failed to connect to compiler: ${error.message}</div>
-            </div>`;
+            output.innerHTML = formatErrorOutput(`Failed to connect to compiler: ${error.message}`);
             updateStatus('error', 'Connection failed');
         }
     }
@@ -573,13 +610,9 @@ print("Demo complete!")`,
                 // Handle HTTP errors that still have JSON error details
                 if (result.error) {
                     output.className = 'error';
-                    const errorLabel = result.isCompilationError ? 'Compilation Error' : 'Execution Error';
                     const statusMessage = result.isCompilationError ? 'Compilation failed' : 'Execution failed';
                     
-                    output.innerHTML = `<div class="output-section">
-                        <div class="output-label">${errorLabel}</div>
-                        <div class="compiler-output">${formatOutput(result.error)}</div>
-                    </div>`;
+                    output.innerHTML = formatErrorOutput(result.error);
                     updateStatus('error', statusMessage);
                     return;
                 } else {
@@ -590,62 +623,139 @@ print("Demo complete!")`,
             if (result.success) {
                 // Successful execution
                 output.className = 'success';
-                let outputHtml = '';
-                
-                if (result.compilerOutput && result.compilerOutput.trim()) {
-                    outputHtml += `<div class="output-section">
-                        <div class="output-label">Compiler Messages</div>
-                        <div class="compiler-output">${formatOutput(result.compilerOutput)}</div>
-                    </div>`;
-                }
+                let outputText = '';
                 
                 if (result.programOutput && result.programOutput.trim()) {
-                    outputHtml += `<div class="output-section">
-                        <div class="output-label">Program Output</div>
-                        <div class="program-output">${formatOutput(result.programOutput)}</div>
-                    </div>`;
+                    outputText = result.programOutput;
                 } else {
-                    outputHtml += `<div class="output-section">
-                        <div class="output-label">Program Output</div>
-                        <div class="program-output">✅ Program ran successfully - no output</div>
-                    </div>`;
+                    outputText = '✅ Program ran successfully - no output';
                 }
                 
-                output.innerHTML = outputHtml;
+                output.innerHTML = formatPlainOutput(outputText);
                 updateStatus('connected', 'Ready');
             } else {
                 // Execution failed
                 output.className = 'error';
-                output.innerHTML = `<div class="output-section">
-                    <div class="output-label">Execution Error</div>
-                    <div class="compiler-output">${formatOutput(result.error)}</div>
-                </div>`;
+                output.innerHTML = formatErrorOutput(result.error || 'Unknown error');
                 updateStatus('error', 'Execution failed');
             }
             
         } catch (error) {
             output.className = 'error';
-            output.innerHTML = `<div class="output-section">
-                <div class="output-label">Network Error</div>
-                <div class="compiler-output">Failed to connect to compiler: ${error.message}</div>
-            </div>`;
+            output.innerHTML = formatErrorOutput(`Failed to connect to compiler: ${error.message}`);
             updateStatus('error', 'Connection failed');
         }
     }
     
-    function formatOutput(text) {
+    function formatErrorOutput(text) {
         if (!text) return '';
         
         // Escape HTML
         text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         
-        // Highlight line numbers - more comprehensive patterns
-        text = text.replace(/(\bline\s+)(\d+)(\s*:\s*\d+)?/gi, '$1<span class="line-number">$2$3</span>');
-        text = text.replace(/(\bat line\s+)(\d+)/gi, '$1<span class="line-number">$2</span>');
-        text = text.replace(/(\berror at\s+)(\d+)/gi, '$1<span class="line-number">$2</span>');
-        text = text.replace(/(\[)(\d+)(\s*:\s*\d+)(\])/g, '$1<span class="line-number">$2$3</span>$4');
+        // Split by lines and parse errors
+        const lines = text.split('\n').filter(line => line.trim());
+        const errorLines = [];
+        
+        lines.forEach(line => {
+            // Check if line contains line number references
+            const lineNumberMatch = line.match(/\b(?:line\s+)(\d+)(?:\s*:\s*(\d+))?/i) ||
+                                  line.match(/\bat line\s+(\d+)/i) ||
+                                  line.match(/\berror at\s+(\d+)/i) ||
+                                  line.match(/\[(\d+)(?:\s*:\s*(\d+))?\]/);
+            
+            if (lineNumberMatch) {
+                const lineNum = parseInt(lineNumberMatch[1]);
+                const column = lineNumberMatch[2] ? parseInt(lineNumberMatch[2]) : 0;
+                
+                // Extract the error message (everything after the line number)
+                let message = line.replace(/^.*?(?:line\s+\d+(?::\d+)?|at line\s+\d+|\[\d+(?::\d+)?\])\s*/, '').trim();
+                if (!message) message = line.trim();
+                
+                errorLines.push({
+                    lineNum,
+                    column,
+                    message,
+                    fullText: line
+                });
+            } else {
+                // Non-line-specific error
+                errorLines.push({
+                    lineNum: null,
+                    column: null,
+                    message: line.trim(),
+                    fullText: line
+                });
+            }
+        });
+        
+        if (errorLines.length === 0) {
+            return text; // Fallback to original text
+        }
+        
+        // Build clean grid structure
+        const gridItems = errorLines.map(error => {
+            if (error.lineNum !== null) {
+                const location = error.column > 0 ? `${error.lineNum}:${error.column}` : `${error.lineNum}`;
+                return `<div class="error-line" onclick="jumpToLine(${error.lineNum}, ${error.column || 1})">
+                    <span class="error-location">Line ${location}</span>
+                    <span class="error-message">${error.message}</span>
+                </div>`;
+            } else {
+                return `<div class="error-line">
+                    <span class="error-location">—</span>
+                    <span class="error-message">${error.message}</span>
+                </div>`;
+            }
+        });
+        
+        return `<div class="error-list">${gridItems.join('')}</div>`;
+    }
+    
+    function formatPlainOutput(text) {
+        if (!text) return '';
+        
+        // Escape HTML
+        text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        
+        // Color specific messages
+        text = text.replace(/(Program executed successfully)/g, '<span style="color: #7cb992;">$1</span>');
+        text = text.replace(/(Running program\.\.\.)/g, '<span style="color: #ffa500;">$1</span>');
         
         return text;
+    }
+    
+    function jumpToLine(lineNumber, column = 1) {
+        if (!editor) return;
+        
+        console.log(`🎯 Jumping to line ${lineNumber}, column ${column}`);
+        
+        // Remove any existing selections
+        const errorLines = document.querySelectorAll('.error-line');
+        errorLines.forEach(el => el.classList.remove('selected'));
+        
+        // Mark clicked line as selected
+        event.target.closest('.error-line')?.classList.add('selected');
+        
+        // Jump to the line in Monaco editor
+        editor.setPosition({ lineNumber: lineNumber, column: column });
+        editor.revealLineInCenter(lineNumber);
+        editor.focus();
+        
+        // Optionally highlight the line temporarily
+        const decoration = editor.deltaDecorations([], [{
+            range: new monaco.Range(lineNumber, 1, lineNumber, 1),
+            options: {
+                isWholeLine: true,
+                className: 'highlighted-error-line',
+                glyphMarginClassName: 'error-glyph'
+            }
+        }]);
+        
+        // Remove decoration after 2 seconds
+        setTimeout(() => {
+            editor.deltaDecorations(decoration, []);
+        }, 2000);
     }
     
     function clearOutput() {

--- a/website/src/spec.md
+++ b/website/src/spec.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Osprey Language Specification"
 description: "Complete language specification and syntax reference for the Osprey programming language"
-date: 2025-06-18
+date: 2025-06-22
 tags: ["specification", "reference", "documentation"]
 author: "Christian Findlay"
 permalink: "/spec/"


### PR DESCRIPTION
# TLDR
Improves error reporting and separates compiler/program outputs for web compiler playground

# What Was Added?
- Distinct `compilerOutput` and `programOutput` in API responses.
- More detailed error reporting on the frontend (playground) with clickable line numbers.
- Status codes to differentiate compilation and runtime errors.

# What Was Changed / Deleted?
- Removed the prepended "Running program..." message from the CLI output.
- Modified the web compiler API to return separate outputs.
- Updated the playground to display compiler and program outputs distinctly and handle compilation errors more gracefully.

# How Do The Automated Tests Prove It Works?
- CLI tests now expect empty output for successful runs, relying on stderr for compiler messages.
- Web compiler can now distinguish between different kind of errors (compilation vs execution).

# Summarise Changes To The Spec Here
