### PR TITLE
Fix Playground Builds all runtime libraries in Dockerfile

### DIFF
--- a/webcompiler/Dockerfile
+++ b/webcompiler/Dockerfile
@@ -18,11 +18,8 @@ RUN apt-get update && apt-get upgrade -y \
 COPY compiler /workspace
 WORKDIR /workspace
 
-# Build fiber runtime first
-RUN make fiber-runtime
-
-# Build HTTP runtime
-RUN make http-runtime
+# Build all runtime libraries
+RUN make fiber-runtime http-runtime websocket-runtime system-runtime
 
 # Build the Osprey compiler directly without linting
 RUN go build -o bin/osprey ./cmd/osprey


### PR DESCRIPTION
Addresses the need to build all runtime libraries within the Dockerfile.

# TLDR
The change streamlines the build process by building all runtime libraries in a single step within the Dockerfile.

# What Was Added?
The change adds `websocket-runtime` and `system-runtime` to the build process in the Dockerfile.

# What Was Changed / Deleted?
The change combines the individual `make` commands for `fiber-runtime` and `http-runtime` into a single command that builds all runtime libraries, including the newly added ones. This removes the separate build steps, simplifying the Dockerfile.

# How Do The Automated Tests Prove It Works?
The Dockerfile change primarily affects the build process. Automated tests should be in place to verify that the resulting compiler binary functions correctly with all runtime libraries.  Building all runtime libraries in the Dockerfile ensures that the compiler is built with all required dependencies and the built compiler binary can use all runtime libraries.

# Summarise Changes To The Spec Here
No changes to the specification are made.