### PR TITLE
Increases Resource Allocation for Web Compiler

### DIFF
--- a/webcompiler/fly.toml
+++ b/webcompiler/fly.toml
@@ -29,5 +29,5 @@ primary_region = 'ord'
     idle_timeout = 5
 
 [[vm]]
-  size = 'shared-cpu-1x'
-  memory = '256mb'
+  size = 'shared-cpu-2x'
+  memory = '512mb'

--- a/webcompiler/src/server.js
+++ b/webcompiler/src/server.js
@@ -342,7 +342,7 @@ function runOspreyCompiler(args, code = '') {
             const child = spawn(ospreyPath, [tempFile, ...args], {
                 stdio: 'pipe',
                 cwd: tempRequestDir, // Run in the temp directory
-                timeout: 15000 
+                timeout: 20000 
             })
 
             let stdout = ''


### PR DESCRIPTION
# TLDR
Increases the resource allocation for the web compiler service on Fly.io to improve performance and prevent timeouts.

# What Was Added?
- N/A

# What Was Changed / Deleted?
- Updates the Fly.io configuration to use a larger machine size (`shared-cpu-2x`) and more memory (`512mb`).
- Increases the compiler timeout to 20 seconds.

# How Do The Automated Tests Prove It Works?
The automated tests are not directly modified in this PR, but the increased resource allocation should indirectly improve their reliability by preventing timeouts during compilation.

# Summarise Changes To The Spec Here
No changes to the specification.