### PR TITLE
chore: trim and standardize compiler specs

### DIFF
--- a/compiler/spec/0001-Introduction.md
+++ b/compiler/spec/0001-Introduction.md
@@ -1,28 +1,18 @@
 # Introduction
 
-Osprey is a functional programming language designed for safety, performance, and expressiveness.
+Osprey is a statically-typed functional language in the ML family. It compiles to native code via LLVM.
 
 ## Core Features
 
-- Named arguments for multi-parameter functions
-- Hindley-Milner type inference with strong static typing
-- Pattern matching for all conditional logic
-- Immutable-by-default with explicit mutability
-- Algebraic effects with compile-time safety
-- Result types for all error cases (no exceptions or panics)
-- Built-in HTTP/WebSocket support with streaming
-- Lightweight fiber-based concurrency
+- Hindley-Milner type inference; explicit annotations are optional.
+- Pattern matching as the only conditional construct (no `if`/`else`).
+- Immutable bindings by default; `mut` opts in to mutability.
+- Algebraic effects checked at compile time.
+- `Result<T, E>` for all fallible operations; no exceptions, panics, or null.
+- Named arguments required for functions of two or more parameters.
+- Lightweight fibers and channel-based concurrency.
+- Built-in HTTP and WebSocket support.
 
-## Design Principles
+## Status
 
-- **Safety**: Make illegal states unrepresentable through static verification
-- **Simplicity**: One idiomatic way to accomplish each task
-- **Performance**: LLVM compilation with Rust interop for performance-critical code
-- **Functional**: Referential transparency, immutable data structures, pure functions
-- **Type Safety**: Strong static typing with Hindley-Milner inference; `any` type requires explicit declaration, and accessing values on `any` requires pattern matching
-- **No Exceptions**: All error cases return Result types, enforced at compile time
-- **ML Heritage**: Syntax and semantics inspired by ML family languages
-
-## Development Status
-
-This specification is the authoritative source for Osprey syntax and behavior. The language and compiler are under active development; implementation status is noted where relevant.
+This specification is the authoritative source for Osprey syntax and behaviour. The language and compiler are under active development; implementation status is called out per chapter where it diverges from the specification.

--- a/compiler/spec/0002-LexicalStructure.md
+++ b/compiler/spec/0002-LexicalStructure.md
@@ -16,7 +16,7 @@ ID := [a-zA-Z_][a-zA-Z0-9_]*
 ## Keywords
 
 ```
-fn let mut type import match if then else case of extern
+fn let mut type match extern import effect perform handle in as
 ```
 
 ## Literals
@@ -68,43 +68,17 @@ INTERPOLATION := '${' EXPRESSION '}'
 LIST := '[' (expression (',' expression)*)? ']'
 ```
 
-**Examples:**
 ```osprey
-let numbers = [1, 2, 3, 4]  // Fixed size: 4 elements
-let names = ["Alice", "Bob", "Charlie"]  // Fixed size: 3 elements
-let pair = [x, y]  // Fixed size: 2 elements
+let numbers = [1, 2, 3, 4]
+let names   = ["Alice", "Bob", "Charlie"]
+let pair    = [x, y]
 ```
 
 ## Operators
 
 ### Arithmetic Operators
 
-All arithmetic operators return `Result` types to handle overflow, underflow, and division by zero.
-
-**Integer Operations:**
-- `+` Addition: `(int, int) -> Result<int, MathError>`
-- `-` Subtraction: `(int, int) -> Result<int, MathError>`
-- `*` Multiplication: `(int, int) -> Result<int, MathError>`
-- `/` Division: `(int, int) -> Result<float, MathError>` — always returns float
-- `%` Modulo: `(int, int) -> Result<int, MathError>`
-
-**Floating-Point Operations:**
-- `+`, `-`, `*`, `/`, `%`: `(float, float) -> Result<float, MathError>`
-
-**Type Safety:**
-- No automatic type promotion between int and float
-- Use `toFloat(int)` and `toInt(float)` for explicit conversion
-- Division `/` always returns float, even for integer operands
-
-**Examples:**
-```osprey
-let sum = 5 + 3           // Result<int, MathError>
-let quotient = 10 / 3     // Result<float, MathError> - returns 3.333...
-let remainder = 10 % 3    // Result<int, MathError> - returns 1
-
-let precise = 10.0 / 3.0  // Result<float, MathError>
-let divZero = 10 / 0      // Result<float, MathError> - Error(DivisionByZero)
-```
+`+`, `-`, `*`, `/`, `%`. All arithmetic returns `Result`; full signatures and semantics are in [Error Handling](0013-ErrorHandling.md).
 
 ### Comparison Operators
 - `==` Equality
@@ -123,9 +97,11 @@ let divZero = 10 / 0      // Result<float, MathError> - Error(DivisionByZero)
 - `=` Assignment
 
 ### Other Operators
-- `=>` Lambda/Match arm arrow
+- `->` Function return type
+- `=>` Lambda body and match arm
 - `|` Union type separator
-- `::` Type annotation
+- `|>` Pipe
+- `!` Effect-set marker on a function type
 
 ## Delimiters
 

--- a/compiler/spec/0003-Syntax.md
+++ b/compiler/spec/0003-Syntax.md
@@ -1,588 +1,245 @@
 # Syntax
 
+This chapter defines the syntactic forms that make up an Osprey program. Semantics for individual constructs are in their dedicated chapters; cross-references are noted inline.
+
 - [Program Structure](#program-structure)
-- [Import Statements](#import-statements)
+- [Imports](#imports)
 - [Let Declarations](#let-declarations)
 - [Function Declarations](#function-declarations)
 - [Extern Declarations](#extern-declarations)
 - [Type Declarations](#type-declarations)
-- [Record Types and Type Constructors](#record-types-and-type-constructors)
+- [Records](#records)
 - [Expressions](#expressions)
-- [Block Expressions](#block-expressions)
+- [Field Access](#field-access)
 - [Match Expressions](#match-expressions)
+- [Variable Binding](#variable-binding)
 
 ## Program Structure
 
-An Osprey program consists of a sequence of top-level statements and modules.
-
-```
-program := statement* EOF
-
-statement := importStmt
-          | letDecl
-          | fnDecl
-          | externDecl
-          | typeDecl
-          | moduleDecl
-          | exprStmt
+```ebnf
+program   ::= statement* EOF
+statement ::= importStmt
+            | letDecl
+            | fnDecl
+            | externDecl
+            | typeDecl
+            | moduleDecl
+            | exprStmt
 ```
 
-## Import Statements
+## Imports
 
-Basic import parsing is implemented but module resolution is limited.
-
-```
-importStmt := IMPORT ID (DOT ID)*
+```ebnf
+importStmt ::= "import" ID ("." ID)*
 ```
 
-**Examples:**
 ```osprey
 import std
 import std.io
 import graphics.canvas
 ```
 
-### Let Declarations
+## Let Declarations
 
-```
-letDecl := (LET | MUT) ID (COLON type)? EQ expr
+```ebnf
+letDecl ::= ("let" | "mut") ID (":" type)? "=" expr
 ```
 
-**Examples:**
 ```osprey
-let x = 42
-let name = "Alice"
+let x       = 42
+let name    = "Alice"
 mut counter = 0
-let result = calculateValue(input: data)
+let result  = calculateValue(input: data)
 ```
 
-### Function Declarations
+`let` binds immutably; `mut` binds mutably. Type annotations are optional.
 
+## Function Declarations
+
+```ebnf
+fnDecl    ::= docComment? "fn" ID "(" paramList? ")" ("->" type)? effectSet?
+              ("=" expr | "{" blockBody "}")
+paramList ::= param ("," param)*
+param     ::= ID (":" type)?
 ```
-fnDecl := docComment? FN ID LPAREN paramList? RPAREN (ARROW type)? (EQ expr | LBRACE blockBody RBRACE)
 
-paramList := param (COMMA param)*
-param := ID (COLON type)?
-```
-
-**Examples:**
 ```osprey
-fn double(x) = x * 2
-fn add(x, y) = x + y
+fn double(x)   = x * 2
+fn add(x, y)   = x + y
 fn greet(name) = "Hello " + name
-fn getValue() = 42
+fn getValue()  = 42
 ```
 
-### Extern Declarations
+Effect sets (`!E`) are described in [Algebraic Effects](0017-AlgebraicEffects.md). Functions of two or more parameters require named arguments at call sites; see [Function Calls](0005-FunctionCalls.md).
 
-Extern declarations allow Osprey programs to call functions implemented in other languages (such as Rust, C, or C++). These declarations specify the interface for external functions without providing an implementation.
+## Extern Declarations
 
+`extern` declares an interface to a foreign function (Rust, C, or any C-ABI library). It has no body.
+
+```ebnf
+externDecl      ::= docComment? "extern" "fn" ID "(" externParamList? ")" ("->" type)?
+externParamList ::= externParam ("," externParam)*
+externParam     ::= ID ":" type
 ```
-externDecl := docComment? EXTERN FN ID LPAREN externParamList? RPAREN (ARROW type)?
 
-externParamList := externParam (COMMA externParam)*
-externParam := ID COLON type
-```
+Parameter types are required. Calls use named arguments (single-parameter functions may use positional).
 
-**Key Features:**
-- **Required type annotations**: All parameters must have explicit type annotations
-- **Optional return type**: Return type can be specified with `-> type` syntax
-- **No function body**: Extern declarations only specify the interface
-- **Interoperability**: Enables calling functions from Rust, C, and other languages
-
-**Examples:**
 ```osprey
-// Basic extern function declarations
 extern fn rust_add(a: int, b: int) -> int
-extern fn rust_multiply(a: int, b: int) -> int
-extern fn rust_factorial(n: int) -> int
-
-// Using extern functions with named arguments
-let sum = rust_add(a: 15, b: 25)
-let product = rust_multiply(a: 6, b: 7)
-let factorial = rust_factorial(5)
-
-// Extern functions with different return types
 extern fn rust_is_prime(n: int) -> bool
-extern fn rust_format_number(n: int) -> string
 
+let sum     = rust_add(a: 15, b: 25)
 let isPrime = rust_is_prime(17)
-let formatted = rust_format_number(42)
 ```
 
-**Type Mapping:**
-- Osprey `int` ↔ Rust `i64` ↔ C `int64_t`
-- Osprey `bool` ↔ Rust `bool` ↔ C `bool`
-- Osprey `string` ↔ Rust `*const c_char` ↔ C `char*`
+ABI mapping:
 
-**Implementation Requirements:**
-- External functions must use C ABI (`extern "C"` in Rust)
-- Functions must be marked with `#[no_mangle]` in Rust
-- Static libraries must be linked during compilation
+| Osprey   | Rust                | C            |
+| -------- | ------------------- | ------------ |
+| `int`    | `i64`               | `int64_t`    |
+| `bool`   | `bool`              | `bool`       |
+| `string` | `*const c_char`     | `char *`     |
 
-### Type Declarations
+The foreign function must use the C ABI (`extern "C"` and `#[no_mangle]` in Rust) and be linked at compile time.
 
-```
-typeDecl := docComment? TYPE ID (LT typeParamList GT)? EQ (unionType | recordType)
+## Type Declarations
 
-unionType := variant (BAR variant)*
-recordType := LBRACE fieldDeclarations RBRACE
-
-variant := ID (LBRACE fieldDeclarations RBRACE)?
-
-fieldDeclarations := fieldDeclaration (COMMA fieldDeclaration)*
-fieldDeclaration := ID COLON type constraint?
-
-constraint := WHERE function_name
+```ebnf
+typeDecl          ::= docComment? "type" ID ("<" typeParamList ">")? "=" (unionType | recordType)
+unionType         ::= variant ("|" variant)*
+recordType        ::= "{" fieldDeclarations "}"
+variant           ::= ID ("{" fieldDeclarations "}")?
+fieldDeclarations ::= fieldDeclaration ("," fieldDeclaration)*
+fieldDeclaration  ::= ID ":" type constraint?
+constraint        ::= "where" function_name
 ```
 
-**Examples:**
 ```osprey
 type Color = Red | Green | Blue
 
-type Shape = Circle { radius: int } 
+type Shape = Circle    { radius: int }
            | Rectangle { width: int, height: int }
-
-type Result = Success { value: string } 
-            | Error { message: string }
 ```
 
-### Record Types and Type Constructors
+## Records
 
-Record types define structured data with named fields using the following syntax:
+A record type names a fixed set of fields. Construction uses `TypeName { field: value, ... }`; field order at the call site is irrelevant.
 
-```
-record_type := 'type' ID '=' '{' field_declarations '}' validation?
-
-field_declarations := field_declaration (',' field_declaration)*
-field_declaration := ID ':' type
-validation := 'where' function_name
-
-type_constructor := type_name '{' field_assignments '}'
-field_assignments := field_assignment (',' field_assignment)*
-field_assignment := ID ':' expression
-```
-
-**Examples:**
 ```osprey
-type Point = { x: int, y: int }
+type Point  = { x: int, y: int }
 type Person = { name: string, age: int } where validatePerson
 
-let point = Point { x: 10, y: 20 }
+let point  = Point { x: 10, y: 20 }
 let person = Person { name: "Alice", age: 25 }
 ```
 
-For complete record type semantics, construction rules, field access, constraints, and validation behavior, see [Type System - Record Types](0004-TypeSystem.md#record-types).
+Validation, non-destructive update (`record { field: value }`), and full field-access semantics are in [Type System](0004-TypeSystem.md).
 
-### Expressions
+## Expressions
 
-#### Binary Expressions
-```
-binary_expression := multiplicative_expression (('+' | '-') multiplicative_expression)*
+```ebnf
+expression          ::= logicalOrExpression
+logicalOrExpression ::= logicalAndExpression ("||" logicalAndExpression)*
+logicalAndExpression::= comparisonExpression ("&&" comparisonExpression)*
+comparisonExpression::= additiveExpression (("==" | "!=" | "<" | ">" | "<=" | ">=") additiveExpression)*
+additiveExpression  ::= multiplicativeExpression (("+" | "-") multiplicativeExpression)*
+multiplicativeExpression ::= unaryExpression (("*" | "/") unaryExpression)*
+unaryExpression     ::= ("+" | "-" | "!")? pipeExpression
+pipeExpression      ::= callExpression ("|>" callExpression)*
+callExpression      ::= primaryExpression (
+                          "." ID "(" argumentList? ")"
+                        | "(" argumentList? ")"
+                        | "[" expression "]"
+                        | "." ID
+                      )*
+primaryExpression   ::= literal | ID | "(" expression ")"
+                      | lambdaExpression | blockExpression | matchExpression
 
-multiplicative_expression := unary_expression (('*' | '/') unary_expression)*
-```
-
-#### Unary Expressions
-
-```
-unary_expression := ('+' | '-')? pipe_expression
-```
-
-#### Function Calls
-
-```
-call_expression := primary ('.' ID '(' argument_list? ')')* 
-                | primary ('(' argument_list? ')')?
-
-argument_list := named_argument_list 
-              | positional_argument_list
-
-named_argument_list := named_argument (',' named_argument)+
-named_argument := ID ':' expression
-
-positional_argument_list := expression (',' expression)*
+argumentList        ::= namedArgument ("," namedArgument)+
+                      | expression ("," expression)*
+namedArgument       ::= ID ":" expression
 ```
 
-#### Primary Expressions
+Precedence, highest to lowest:
 
-```
-primary_expression := literal
-                   | identifier
-                   | '(' expression ')'
-                   | lambda_expression
-                   | block_expression
-```
+1. Unary `!`, `-`
+2. Multiplicative `*`, `/`, `%`
+3. Additive `+`, `-`
+4. Comparison `==`, `!=`, `<`, `>`, `<=`, `>=`
+5. Logical AND `&&`
+6. Logical OR `||`
 
+Block expressions and their scoping are defined in [Block Expressions](0008-BlockExpressions.md). Pattern-matching for booleans (the only conditional construct) is in [Boolean Operations](0009-BooleanOperations.md).
 
-#### Binary Expressions
-```
-binary_expression := logical_or_expression
-logical_or_expression := logical_and_expression ('||' logical_and_expression)*
-logical_and_expression := comparison_expression ('&&' comparison_expression)*
-comparison_expression := additive_expression (('==' | '!=' | '<' | '>' | '<=' | '>=') additive_expression)*
-additive_expression := multiplicative_expression (('+' | '-') multiplicative_expression)*
-multiplicative_expression := unary_expression (('*' | '/') unary_expression)*
+## List Access
+
+```ebnf
+listAccess ::= expression "[" expression "]"
 ```
 
-**Operator Precedence (highest to lowest):**
-1. Unary operators (`!`, `-`)
-2. Multiplicative (`*`, `/`)  
-3. Additive (`+`, `-`)
-4. Comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`)
-5. Logical AND (`&&`)
-6. Logical OR (`||`)
-
-#### Boolean Pattern Matching
-Use pattern matching for conditional logic:
-
-**Examples:**
-```osprey
-let result = match x > 0 {
-    true => "positive"
-    false => "zero or negative"
-}
-
-let max = match a > b {
-    true => a
-    false => b
-}
-```
-
-#### List Access
-
-```
-list_access := expression '[' INT ']'  // Returns Result<T, IndexError>
-```
-
-List access always returns `Result<T, IndexError>` for bounds safety and must be handled with pattern matching:
+Indexing returns `Result<T, IndexError>`:
 
 ```osprey
 let numbers = [1, 2, 3, 4]
 
-let firstResult = numbers[0]  // Result<int, IndexError>
-match firstResult {
-    Success { value } => print("First: ${value}")
-    Error { message } => print("Index error: ${message}")
-}
-
-// Inline pattern matching
-let second = match numbers[1] {
-    Success { value } => value
-    Error { _ } => -1
+match numbers[0] {
+    Success { value }   => print("first: ${value}")
+    Error   { message } => print("index error: ${message}")
 }
 ```
 
-#### Field Access
+## Field Access
 
-Field access uses dot notation to access fields of record types:
-
-```
-field_access := expression '.' identifier
+```ebnf
+fieldAccess ::= expression "." ID
 ```
 
-**Examples:**
-```osprey
-type Person = { name: String, age: Int }
-let person = Person { name: "Alice", age: 25 }
-
-// Field access on record types
-let name = person.name        // "Alice"
-let age = person.age          // 25
-
-// Field access in expressions
-print("Name: ${person.name}")
-print("Age: ${person.age}")
-
-// Field access in function calls
-sendEmail(to: person.name, subject: "Hello")
-```
-
-#### Field Access Rules
-
-Field access is allowed on record types:
+Fields are accessible directly only on record values:
 
 ```osprey
 type User = { id: int, name: string }
-let user = User { id: 1, name: "Alice" }
-let userId = user.id          // Valid
-let userName = user.name      // Valid
+let user  = User { id: 1, name: "Alice" }
+let n     = user.name
 ```
 
-Field access requires pattern matching for:
-- **`any` types**: Extract fields through structural patterns
-- **Result types**: Unwrap Result before accessing fields
-- **Union types**: Match variant before accessing fields
+Field access on `any`, `Result`, or any union type requires a `match` to narrow the value first. See [Type System](0004-TypeSystem.md) for the full rules.
+
+Records are immutable. Use the non-destructive update form to produce a modified copy:
 
 ```osprey
-// any type - use pattern matching
-fn processAny(value: any) -> string = match value {
-    person: { name } => person.name
-    _ => "unknown"
-}
-
-// Result type - unwrap first
-match personResult {
-    Success { value } => print("Name: ${value.name}")
-    Error { message } => print("Error: ${message}")
-}
+let p2 = point { x: 15 }   // y carried over
 ```
 
-#### Structural Field Access
+## Match Expressions
 
-Osprey supports structural field access through pattern matching, allowing access to fields regardless of the specific type:
+```ebnf
+matchExpr   ::= "match" expr "{" matchArm+ "}"
+matchArm    ::= pattern "=>" expr
+pattern     ::= unaryExpr                              (* literals incl. -1, +42 *)
+              | ID ("{" fieldPattern "}")?             (* constructor / destructure *)
+              | ID "(" pattern ("," pattern)* ")"      (* positional constructor *)
+              | ID ":" type                            (* type annotation *)
+              | ID ":" "{" fieldPattern "}"            (* named structural *)
+              | "{" fieldPattern "}"                   (* anonymous structural *)
+              | "_"                                    (* wildcard *)
+fieldPattern::= ID ("," ID)*
+```
 
 ```osprey
-// Any type with 'name' and 'age' fields can be matched
-fn processEntity(entity: any) -> String = match entity {
-    { name, age } => "Entity ${name} is ${age}"           // Structural matching
-    person: { name } => "Named entity: ${person.name}"    // Named structural matching  
-    _ => "Unknown entity"
-}
+type Status = Ready | Running | Done { code: int }
 
-// Works with any type that has these fields
-type Person = { name: String, age: Int }
-type Employee = { name: String, age: Int, department: String }
-
-let person = Person { name: "Alice", age: 25 }
-let employee = Employee { name: "Bob", age: 30, department: "Engineering" }
-
-// Both work with the same function
-print(processEntity(person))     // "Entity Alice is 25"
-print(processEntity(employee))   // "Entity Bob is 30"
-```
-
-#### Immutability and Field Access
-
-All record types are immutable by default. Field access returns the current value and cannot be used for assignment:
-
-```osprey
-type Point = { x: Int, y: Int }
-let point = Point { x: 10, y: 20 }
-
-let x = point.x              // ✅ Valid: read field value
-let y = point.y              // ✅ Valid: read field value
-
-// ERROR: Cannot assign to fields (immutable by default)
-point.x = 15                 // ❌ Compilation error
-
-// CORRECT: Create new instance with updated values
-let newPoint = point { x: 15 }   // ✅ Non-destructive update syntax
-print("New point: ${newPoint.x}, ${newPoint.y}")  // 15, 20
-```
-
-#### Primary Expressions
-```
-primary_expression := literal | list_literal | identifier | '(' expression ')' 
-                   | list_access | field_access | lambda_expression | block_expression | match_expression
-```
-
-### Block Expressions
-
-Block expressions allow grouping multiple statements together and returning a value from the final expression. They create a new scope for variable declarations and enable sequential execution with proper scoping rules.
-
-```
-block_expression := '{' statement* expression? '}'
-```
-
-**Examples:**
-```osprey
-// Simple block with local variables
-let result = {
-    let x = 10
-    let y = 20
-    x + y
-}
-print("Result: ${result}")  // prints "Result: 30"
-
-// Nested blocks
-let complex = {
-    let outer = 100
-    let inner_result = {
-        let inner = 50
-        outer + inner
-    }
-    inner_result * 2
-}
-print("Complex: ${complex}")  // prints "Complex: 300"
-
-// Block with function calls
-fn multiply(a: int, b: int) -> int = a * b
-let calc = {
-    let a = 5
-    let b = 6
-    multiply(a: a, b: b)
-}
-print("Calculation: ${calc}")  // prints "Calculation: 30"
-```
-
-#### Block Scoping Rules
-
-Block expressions create a new lexical scope:
-- Variables declared inside a block are only visible within that block
-- Variables from outer scopes can be accessed (lexical scoping)
-- Variables declared in a block shadow outer variables with the same name
-- Variables go out of scope when the block ends
-
-**Scoping Examples:**
-```osprey
-let x = 100
-let result = {
-    let x = 50        // Shadows outer x
-    let y = 25        // Only visible in this block
-    x + y             // Uses inner x (50)
-}
-print("Result: ${result}")  // 75
-print("Outer x: ${x}")      // 100 (unchanged)
-// print("${y}")            // ERROR: y not in scope
-```
-
-#### Block Return Values
-
-Block expressions return the value of their final expression:
-- If the block ends with an expression, that value is returned
-- If the block has no final expression, it returns the unit type
-- The block's type is determined by the type of the final expression
-
-**Return Value Examples:**
-```osprey
-// Block returns integer
-let number = {
-    let a = 10
-    let b = 20
-    a + b           // Returns 30
-}
-
-// Block returns string
-let message = {
-    let name = "Alice"
-    let age = 25
-    "Hello ${name}, age ${age}"  // Returns string
-}
-
-// Block with statements only (returns unit)
-let side_effect = {
-    print("Doing work...")
-    print("Work complete")
-    // No final expression - returns unit
+let label = match status {
+    Ready          => "ready"
+    Running        => "running"
+    Done { code }  => "done (${code})"
 }
 ```
 
-#### Block Expressions in Match Arms
+Pattern semantics, exhaustiveness, and the ternary shorthand are in [Pattern Matching](0007-PatternMatching.md).
 
-Block expressions are particularly useful in match expressions for complex logic:
+## Variable Binding
 
-```osprey
-let result = match status {
-    Success => {
-        print("Operation succeeded")
-        let timestamp = getCurrentTime()
-        "Success at ${timestamp}"
-    }
-    Error => {
-        print("Operation failed")
-        let error_code = getErrorCode()
-        "Error ${error_code}"
-    }
-    _ => "Unknown status"
-}
-```
-
-#### Function Bodies as Blocks
-
-Functions can use block expressions as their body instead of single expressions:
-
-```osprey
-fn processData(input: string) -> string = {
-    let cleaned = cleanInput(input)
-    let validated = validateInput(cleaned)
-    let processed = transformData(validated)
-    formatOutput(processed)
-}
-
-// Equivalent to expression-bodied function:
-fn processData(input: string) -> string = 
-    formatOutput(transformData(validateInput(cleanInput(input))))
-```
-
-#### Type Safety and Inference
-
-Block expressions follow Osprey's type safety rules:
-- The block's type is inferred from the final expression
-- All statements in the block must be well-typed
-- Variable declarations in blocks follow the same type inference rules
-- Return type must be compatible with the expected type
-
-**Type Inference Examples:**
-```osprey
-// Block type inferred as Int
-let num: int = {
-    let a = 10
-    let b = 20
-    a + b              // Type: int
-}
-
-// Block type inferred as String
-let text: string = {
-    let name = "Bob"
-    "Hello ${name}"    // Type: string
-}
-
-// ERROR: Type mismatch
-let wrong: int = {
-    let x = 10
-    "not a number"     // ERROR: Expected int, got string
-}
-```
-
-Block expressions are zero-cost abstractions: scoping is resolved at compile time, and simple blocks are optimized away. See [Block Expressions](0008-BlockExpressions.md) for complete details on semantics and usage patterns.
-
-### Match Expressions
-
-```
-matchExpr := MATCH expr LBRACE matchArm+ RBRACE
-
-matchArm := pattern LAMBDA expr
-
-pattern := unaryExpr                                   // Support negative numbers: -1, +42, etc.
-        | ID (LBRACE fieldPattern RBRACE)?          // Pattern destructuring: Ok { value }
-        | ID (LPAREN pattern (COMMA pattern)* RPAREN)?  // Constructor patterns
-        | ID (ID)?                                   // Variable capture
-        | ID COLON type                              // Type annotation pattern: value: Int
-        | ID COLON LBRACE fieldPattern RBRACE       // Named structural: person: { name, age }
-        | LBRACE fieldPattern RBRACE                // Anonymous structural: { name, age }
-        | UNDERSCORE                                 // Wildcard
-
-fieldPattern := ID (COMMA ID)*
-```
-
-**Example:**
-```osprey
-let result = match status {
-    Success => "OK"
-    Error msg => "Failed: " + msg
-    _ => "Unknown"
-}
-```
-
-## Language Semantics
-
-### Variable Binding
-
-- `let` creates immutable bindings
-- `mut` creates mutable bindings
-- Variables must be initialized at declaration
-- Shadowing is allowed in nested scopes
-
-### Function Semantics
-
-- Functions are first-class values
-- All functions are pure (no side effects except I/O)
-- Recursive functions are supported
-- Tail recursion is optimized
-
-### Evaluation Order
-
-- Expressions are evaluated left-to-right
-- Function arguments are evaluated before the function call
-- Short-circuit evaluation for logical operators
+- `let` creates an immutable binding; `mut` creates a mutable one.
+- Every binding is initialised at declaration.
+- Inner scopes may shadow outer bindings.
+- Function arguments evaluate left to right before the call. `&&` and `||` short-circuit.

--- a/compiler/spec/0004-TypeSystem.md
+++ b/compiler/spec/0004-TypeSystem.md
@@ -1,1236 +1,413 @@
 # Type System
 
-- [Hindley-Milner Type Inference](#hindley-milner-type-inference)
+- [Hindley-Milner Inference](#hindley-milner-inference)
 - [Built-in Types](#built-in-types)
-- [Type Safety](#type-safety)
-- [Any Type Handling](#any-type-handling)
-- [Type Compatibility](#type-compatibility)
+- [Result Auto-Unwrapping](#result-auto-unwrapping)
+- [Function Types](#function-types)
+- [Record Types](#record-types)
+- [Validated Records (`where`)](#validated-records-where)
+- [Collection Types](#collection-types)
+- [Built-in Error Types](#built-in-error-types)
+- [The `any` Type](#the-any-type)
+- [Type Annotation Requirements](#type-annotation-requirements)
 
-## Hindley-Milner Type Inference
+## Hindley-Milner Inference
 
-Osprey implements Hindley-Milner type inference as its foundational type system. This provides:
+Osprey uses Hindley-Milner inference. Every well-typed expression has a unique most general type, inference always terminates, and a successful type-check guarantees no runtime type errors.
 
-1. **Complete type inference**: Variables and functions can be declared without explicit type annotations
-2. **Principal types**: Every well-typed expression has a unique most general type
-3. **Compile-time safety**: No runtime type errors if program type-checks
-4. **Decidability**: Type inference always terminates
+Type annotations are optional everywhere they can be inferred:
 
-The type system emphasizes safety and expressiveness, making illegal states unrepresentable through static verification.
+```osprey
+fn identity(x)         = x                       // <T>(T) -> T
+fn add(a, b)           = a + b                   // (int, int) -> Result<int, MathError>
+fn greet(name)         = "Hello, " + name        // (string) -> string
+fn makeUser(n, a)      = User { name: n, age: a }  // (string, int) -> User
+fn getName(u)          = u.name                  // (User) -> string
+fn twice(f, x)         = f(f(x))                 // <T>((T) -> T, T) -> T
+fn compose(f, g)       = fn(x) => f(g(x))        // <A,B,C>((B)->C,(A)->B) -> (A)->C
+```
+
+A polymorphic function is monomorphised independently at each call site:
+
+```osprey
+let i = identity(42)        // identity<int>
+let s = identity("hello")   // identity<string>
+```
+
+### Record Type Unification
+
+Two record types unify iff they have the same set of field names and corresponding field types unify. Field order is irrelevant in both declaration and construction.
+
+```
+unify(R1, R2) :=
+    if names(R1) ≠ names(R2) then FAIL
+    else for each f ∈ names(R1): unify(typeOf(R1, f), typeOf(R2, f))
+```
+
+### Polymorphic Variables vs `any`
+
+Inference produces polymorphic variables (`<T>`, `<A>`, …), not `any`. The `any` type is opt-in; see [The `any` Type](#the-any-type).
 
 ## Built-in Types
 
-All primitive types use lowercase names:
+All primitive types are lowercase.
 
-- `int`: 64-bit signed integers (maps to LLVM i64)
-- `float`: 64-bit IEEE 754 floating-point numbers (maps to LLVM f64)
-- `string`: UTF-8 encoded strings
-- `bool`: Boolean values (`true`, `false`)
-- `unit`: Type for functions that don't return a meaningful value
-- `Result<T, E>`: Built-in generic type for error handling
-- `List<T>`: Immutable collections with compile-time safety and zero-cost abstractions
-- `Map<K, V>`: Immutable key-value collections with functional operations
-- `Function Types`: First-class function types with syntax `(T1, T2, ...) -> R`
-- `Record Types`: Immutable structured data types with named fields
+| Type             | Description                                                        |
+| ---------------- | ------------------------------------------------------------------ |
+| `int`            | 64-bit signed integer (LLVM `i64`)                                 |
+| `float`          | 64-bit IEEE 754 (LLVM `double`)                                    |
+| `string`         | UTF-8 encoded                                                      |
+| `bool`           | `true` \| `false`                                                  |
+| `unit`           | The single value `()`; the return type of a function with no result|
+| `any`            | Erased value; access requires pattern matching                     |
+| `Result<T, E>`   | Error-handling sum type (see [Error Handling](0013-ErrorHandling.md)) |
+| `List<T>`        | Immutable sequential collection                                    |
+| `Map<K, V>`      | Immutable key/value collection                                     |
 
-**Numeric Types:**
-- **int**: Used for whole numbers, counts, array indices. 64-bit signed integers.
-- **float**: Used for decimal numbers, scientific calculations. 64-bit IEEE 754 double precision.
-- **Conversion**: Use `toFloat(int)` to convert int to float, `toInt(float)` to truncate float to int.
+`int` and `float` do not implicitly convert. Use `toFloat(int)` and `toInt(float)`.
 
-**Numeric Type Promotion Rules:**
+Arithmetic returns `Result<T, MathError>`. The full operator-by-operand table and chaining rules are in [Error Handling](0013-ErrorHandling.md#arithmetic-returns-result).
 
-Osprey uses automatic type promotion for mixed numeric operations to ensure mathematical correctness:
+## Result Auto-Unwrapping
 
-**Promotion Rules:**
-- **int ⊕ int** → Result<int, MathError> (where ⊕ is +, -, *, %) - Can overflow/underflow
-- **float ⊕ float** → Result<float, MathError> - Can overflow/underflow
-- **int ⊕ float** → Result<float, MathError> (int promoted to float)
-- **float ⊕ int** → Result<float, MathError> (int promoted to float)
-- **int / int** → Result<**float**, MathError> (division ALWAYS returns float!)
+A bare arithmetic expression has type `Result<T, MathError>`. The compiler auto-unwraps the inner `Result` in three contexts so authors do not write nested `match` chains:
 
-**Examples:**
+1. **Nested arithmetic.** `(10 + 5) * 2` has type `Result<int, MathError>`, not `Result<Result<int, MathError>, MathError>`. If any sub-expression errors, the chain errors.
+2. **User function arguments.** Passing a `Result`-typed expression to a function that expects the underlying type unwraps it. `double(add(a: 5, b: 3))` is well-typed when `add` returns `Result<int, MathError>` and `double` expects `int`.
+3. **Fiber operations.** `spawn`, `await`, `send`, and `recv` unwrap `Result` arguments before storing them.
+
+Auto-unwrap does **not** apply to:
+
+- `toString`. `toString(add(a: 5, b: 3))` produces `"Success(8)"`, never `"8"`. Use `toString` to inspect the `Result` itself.
+- A function's declared return type. `fn add(x, y) = x + y` returns `Result<int, MathError>`; `fn compute() -> int = 5` returns `int`.
+
+The top-level value of an arithmetic expression must still be either matched or stored as a `Result`.
+
+## Function Types
+
+```ebnf
+functionType ::= "(" (type ("," type)*)? ")" "->" type
+```
+
 ```osprey
-// Integer arithmetic - ALL return Result types
-let a = 10 + 5       // a: Result<int, MathError> - Could overflow
-let b = 10 * 2       // b: Result<int, MathError> - Could overflow
-let c = 10 - 3       // c: Result<int, MathError> - Could underflow
-
-// Float arithmetic - ALL return Result types
-let d = 3.14 + 2.86  // d: Result<float, MathError> - Could overflow
-let e = 2.5 * 4.0    // e: Result<float, MathError> - Could overflow
-
-// Mixed arithmetic (automatic promotion to float)
-let f = 10 + 5.5     // f: Result<float, MathError> (10 promoted to 10.0)
-let g = 3.14 * 2     // g: Result<float, MathError> (2 promoted to 2.0)
-
-// Division and modulo
-let h = 10 / 2       // h: Result<float, MathError> = Success(5.0)
-let i = 15 / 4       // i: Result<float, MathError> = Success(3.75)
-let j = 10 / 0       // j: Result<float, MathError> = Error(DivisionByZero)
-let k = 10 % 3       // k: Result<int, MathError> = Success(1)
-
-// Using arithmetic results requires pattern matching
-match a {
-    Success { value } => print("Sum: ${value}")
-    Error { message } => print("Overflow: ${message}")
-}
+(int) -> int
+(int, string) -> bool
+() -> string
+(string) -> (int) -> bool          // higher-order
 ```
 
-**Rationale:**
-- **Safety**: ALL arithmetic can fail (overflow, underflow, division by zero) - Result types prevent panics
-- **Consistency**: Division naturally produces rational numbers, so it always returns float
-- **Precision**: Mixed operations promote to float to prevent precision loss
-- **Explicitness**: Pattern matching forces error handling at compile time
-
-### Result Auto-Unwrapping and Nested Arithmetic
-
-**Key Principle:** Arithmetic expressions return Result types, but nested arithmetic automatically unwraps Results to avoid nested pattern matching.
-
-**How It Works:**
-- A single arithmetic expression like `let x = 10 + 5` returns `Result<int, MathError>`
-- Nested expressions like `(10 + 5) * 2` automatically unwrap the inner Result
-- Only the final result needs pattern matching - no nested matching required
-- Error propagation happens at runtime - if any operation fails, the entire chain fails
-
-**Examples:**
 ```osprey
-// Simple arithmetic - returns Result<int, MathError>
-let x = 10 + 5
-match x {
-    Success { value } => print(value)  // Prints: 15
-    Error { message } => print(message)
-}
+fn applyFunction(value: int, transform: (int) -> int) -> int = transform(value)
 
-// Nested arithmetic - automatic unwrapping
-let y = (10 + 5) * 2  // Returns Result<int, MathError>, NOT Result<Result<...>>
-// The (10 + 5) Result is auto-unwrapped before multiplication
-match y {
-    Success { value } => print(value)  // Prints: 30
-    Error { message } => print(message)
-}
+let doubler: (int) -> int = fn(x: int) => x * 2
 
-// Complex chains work seamlessly
-let z = (10 + 5) * (20 - 3) + 7  // Single Result, not nested
-// Each intermediate Result is unwrapped automatically
-
-// Functions can leverage this for clean code
-fn addOne(x: int) -> int =
-    match x + 1 {
-        Success { value } => value  // Extract value for non-Result return
-        Error { message } => 0      // Handle error case
-    }
-
-// Or declare Result return type and skip unwrapping
-fn addOneResult(x: int) -> Result<int, MathError> = x + 1  // Returns Result directly
+fn createAdder(n: int) -> (int) -> int = fn(x: int) => x + n
 ```
 
-**Pattern Matching Requirement:**
-- Top-level arithmetic results MUST be pattern matched or stored as Result types
-- Nested/intermediate Results are automatically unwrapped by the compiler
-- This design balances safety (all errors handled) with ergonomics (no nested matching)
+Multi-argument call syntax (named arguments are required for two or more parameters) is in [Function Calls](0005-FunctionCalls.md).
 
-**Result Auto-Unwrapping Behavior:**
+## Record Types
 
-Result types auto-unwrap in specific contexts to enable ergonomic code:
-
-1. **Arithmetic Operations**: Results unwrap when used in nested arithmetic
-   ```osprey
-   let x = add(5, 3)        // Returns Result<int, MathError>
-   let doubled = x * 2      // x auto-unwraps for multiplication
-   ```
-
-2. **Function Arguments**: Results unwrap when passed to user functions
-   ```osprey
-   fn add(a, b) = a + b
-   fn double(x) = x * 2
-   let result = double(add(5, 3))  // add result unwraps before passing to double
-   ```
-
-3. **Fiber Operations**: Results unwrap for spawn, yield, and channel operations
-   ```osprey
-   let computation = spawn add(5, 3)   // Result unwraps before storing in fiber
-   ```
-
-**IMPORTANT EXCEPTIONS - Do NOT Auto-Unwrap:**
-
-1. **toString() Builtin**: Receives the actual Result struct
-   ```osprey
-   fn add(x, y) = x + y
-   let result = add(5, 3)
-   print(toString(result))   // Prints: Success(8), not "8"
-   ```
-
-2. **Function Return Types**: Functions keep their inferred Result type
-   ```osprey
-   fn add(x, y) = x + y      // Returns Result<int, MathError> struct
-   fn compute() -> int = 5   // Returns plain int
-   ```
-
-**Result toString Format:**
-- Success: `Success(value)` - e.g., `Success(42)`, `Success(3.14)`, `Success(true)`
-- Error: `Error(message)` - e.g., `Error(DivisionByZero)`, `Error(Overflow)`
-
-#### Function Types
-
-Function types represent functions as first-class values, enabling higher-order functions and function composition.
-
-**Syntax:**
-```
-FunctionType := '(' (Type (',' Type)*)? ')' '->' Type
+```ebnf
+recordType ::= "type" ID "=" "{" field ("," field)* "}" constraint?
+field      ::= ID ":" type
+constraint ::= "where" function_name
 ```
 
-**Examples:**
 ```osprey
-(int) -> int              // Function taking an int, returning an int
-(int, string) -> bool     // Function taking int and string, returning bool
-() -> string              // Function with no parameters, returning string
-(string) -> (int) -> bool // Higher-order function returning another function
+type Point   = { x: int, y: int }
+type Person  = { name: string, age: int, active: bool }
 ```
 
-**Function Type Declarations:**
+### Construction
+
 ```osprey
-// Function parameter with explicit function type
-fn applyFunction(value: int, transform: (int) -> int) -> int = 
-    transform(value)
-
-// Variable with function type
-let doubler: (int) -> int = fn(x: int) -> int = x * 2
-
-// Higher-order function that returns a function
-fn createAdder(n: int) -> (int) -> int = 
-    fn(x: int) -> int = x + n
-```
-
-**Function Composition Examples:**
-```osprey
-// Define some simple functions
-fn double(x: int) -> int = x * 2
-fn square(x: int) -> int = x * x
-fn addFive(x: int) -> int = x + 5
-
-// Higher-order function with strong typing
-fn applyTwice(value: int, func: (int) -> int) -> int = 
-    func(func(value))
-
-// Usage with type safety
-let result1 = applyTwice(5, double)  // 20
-let result2 = applyTwice(3, square)  // 81
-let result3 = applyTwice(10, addFive) // 20
-
-// Composition of functions
-fn compose(f: (int) -> int, g: (int) -> int) -> (int) -> int =
-    fn(x: int) -> int = f(g(x))
-
-let doubleSquare = compose(double, square)
-let result4 = doubleSquare(3) // double(square(3)) = double(9) = 18
-```
-
-**Type Safety Benefits:**
-- **Compile-time validation**: Function signatures are checked at compile time
-- **No runtime type errors**: Mismatched function types caught early
-- **Clear documentation**: Function types serve as documentation
-- **Enables optimization**: Compiler can optimize based on known function signatures
-
-#### Record Types
-
-Record types are immutable structured data types with named fields, providing structural equality semantics and compile-time field access validation.
-
-**Syntax:**
-```
-RecordType := 'type' Identifier '=' '{' FieldList '}'
-FieldList  := Field (',' Field)*
-Field      := Identifier ':' Type
-```
-
-**Declaration Examples:**
-```osprey
-type Point = { x: int, y: int }
-type Person = { name: string, age: int, active: bool }
-type Address = { street: string, city: string, zipCode: string }
-```
-
-**Construction Syntax:**
-```osprey
-// Simple record construction
-let point = Point { x: 10, y: 20 }
+let point  = Point  { x: 10, y: 20 }
 let person = Person { name: "Alice", age: 30, active: true }
 
-// Field order is flexible during construction
-let address = Address { 
-    city: "Melbourne",
-    street: "123 Main St", 
-    zipCode: "3000"
+// Field order at construction is irrelevant
+let person2 = Person { active: true, name: "Bob", age: 22 }
+```
+
+All fields are required. Missing or unknown fields, or type mismatches, are compilation errors.
+
+### Field Access
+
+Direct field access is permitted only on a record value. Field access on `any`, `Result`, or any union type requires `match` to narrow the value first.
+
+```osprey
+let n = person.name        // ok
+
+// any: pattern-match
+fn nameOf(v: any) -> string = match v {
+    p: { name } => p.name
+    _           => "unknown"
+}
+
+// Result: match before access
+match personResult {
+    Success { value }   => print(value.name)
+    Error   { message } => print(message)
+}
+
+// Union: discriminate first
+let area = match shape {
+    Circle    { radius }         => 3.14 * radius * radius
+    Rectangle { width, height }  => width * height
 }
 ```
 
-**Field Access:**
-```osprey
-// Direct field access with dot notation
-let x = point.x           // 10
-let name = person.name    // "Alice"
-let isActive = person.active  // true
+The compiler implementation must look up fields by name; positional access is forbidden in code generation.
 
-// Field access in expressions
-let distance = sqrt(point.x * point.x + point.y * point.y)
-let greeting = "Hello, ${person.name}!"
+### Immutability and Non-Destructive Update
+
+Records cannot be modified. To produce a record that differs in some fields from an existing one, use the update form:
+
+```osprey
+let p2 = point  { x: 15 }                // y carried over
+let p3 = person { age: 26, active: false }
 ```
 
-**Key Properties:**
-- **Immutability**: Records cannot be modified after creation
-- **Structural Equality**: Two records are equal if all their fields are equal
-- **Compile-time Field Validation**: Field access is validated at compile time
-- **Type Safety**: Field types are enforced during construction and access
-- **No Null Fields**: All fields must be provided during construction
+### Nested Records
 
-**Pattern Matching with Records:**
-Records support pattern matching for destructuring and value extraction (see [Pattern Matching](0008-PatternMatching.md) for complete details).
-
-**Nested Records:**
 ```osprey
+type Address = { street: string, city: string, zipCode: string }
 type Company = { name: string, address: Address }
 
 let company = Company {
-    name: "Tech Corp",
-    address: Address {
-        street: "456 Tech Ave",
-        city: "Sydney", 
-        zipCode: "2000"
+    name:    "Tech Corp",
+    address: Address { street: "456 Tech Ave", city: "Sydney", zipCode: "2000" }
+}
+
+let companyCity = company.address.city
+```
+
+## Validated Records (`where`)
+
+A `where` clause attaches a validation function to a record type. The constructor of a validated type returns `Result<T, string>` instead of `T`, and the validation function runs at construction time.
+
+```osprey
+type Product = {
+    name:  string,
+    price: int
+} where validateProduct
+
+fn validateProduct(p: Product) -> Result<Product, string> = match p.name {
+    ""  => Error   { message: "name cannot be empty" }
+    _   => match p.price {
+        0 => Error   { message: "price must be positive" }
+        _ => Success { value:   p }
     }
 }
 
-// Nested field access
-let companyCity = company.address.city  // "Sydney"
-```
-
-**Record Updates (Non-destructive):**
-Records support elegant non-destructive updates that create modified copies:
-
-```osprey
-// Original record
-let person = Person { name: "Alice", age: 25, active: true }
-
-// Non-destructive update (creates new instance)
-let olderPerson = person { age: 26 }           // Only age changes
-let renamedPerson = person { name: "Alicia" }  // Only name changes
-
-// Multiple field updates
-let updatedPerson = person { 
-    age: 26, 
-    active: false 
-}
-
-// Original person unchanged - all updates create new instances
-print(person.age)        // Still 25
-print(olderPerson.age)   // Now 26
-```
-
-**Record Type Constraints:**
-Records can have validation constraints using `where` clauses:
-
-```osprey
-type ValidatedPerson = {
-    name: string,
-    age: int,
-    email: string
-} where validatePersonData
-
-fn validatePersonData(person: ValidatedPerson) -> Result<ValidatedPerson, string> = 
-    match person.age {
-        age when age < 0 => Error("Age cannot be negative")
-        age when age > 150 => Error("Age must be realistic")
-        _ => match person.name {
-            "" => Error("Name cannot be empty")
-            _ => Success(person)
-        }
-    }
-
-// Constrained record construction returns Result type
-let result = ValidatedPerson { name: "Bob", age: 25, email: "bob@example.com" }
-// result type: Result<ValidatedPerson, string>
-// Must be handled with pattern matching (see Pattern Matching chapter)
-```
-
-**Field Access Rules:**
-
-Record field access is strictly by name only. Field ordering is not significant and must not be relied upon by the compiler implementation.
-
-```osprey
-type User = { id: int, name: string, email: string }
-let user = User { id: 1, name: "Alice", email: "alice@example.com" }
-
-// Field access by name
-let userId = user.id
-let userName = user.name
-
-// Field order during construction is irrelevant
-let user2 = User {
-    email: "bob@example.com",
-    name: "Bob",
-    id: 2
+// Construction returns Result<Product, string>
+let r = Product { name: "Widget", price: 100 }
+match r {
+    Success { value }   => print("ok: ${value.name}")
+    Error   { message } => print("validation failed: ${message}")
 }
 ```
 
-**Compiler Implementation Requirements:**
-- Field-to-LLVM-index mapping must use field name lookup
-- Type unification must be based on field name matching
-- Pattern matching must use field names
-- Positional field access is forbidden in codegen
+Field access on a validated value is only legal after matching on the `Result`.
 
-**❌ FORBIDDEN - Field Access on `any` Types:**
+## Collection Types
+
+### `List<T>`
+
+Immutable, homogeneous, with structural sharing. Index access is bounds-checked and returns `Result<T, IndexError>`.
+
 ```osprey
-fn processAnyValue(value: any) -> string = {
-    // ERROR: Cannot access fields on 'any' type
-    let result = value.name   // Compilation error
-    return result
-}
+let numbers = [1, 2, 3, 4, 5]            // List<int>
+let names   = ["Alice", "Bob"]           // List<string>
 
-// CORRECT: Use pattern matching for 'any' types
-fn processAnyValue(value: any) -> string = match value {
-    person: { name } => person.name        // Extract field via pattern matching
-    user: User { name } => name           // Type-specific pattern matching
-    _ => "unknown"
-}
-```
+// Empty literal cannot infer its element type unless the context provides it
+let empty: List<int> = []                // ok
+let total = sumOfInts([])                // ok if sumOfInts: (List<int>) -> int
 
-**❌ FORBIDDEN - Field Access on Result Types:**
-```osprey
-type Person = { 
-    name: string
-} where validatePerson
-
-fn validatePerson(person: Person) -> Result<Person, string> = match person.name {
-    "" => Error("Name cannot be empty")
-    _ => Success(person)
-}
-
-let personResult = Person { name: "Alice" }  // Returns Result<Person, string>
-
-// ERROR: Cannot access fields on Result type
-let name = personResult.name    // Compilation error
-
-// CORRECT: Pattern match on Result first
-let name = match personResult {
-    Success { value } => value.name
-    Error { message } => "error"
+match numbers[0] {
+    Success { value }   => print(value)
+    Error   { message } => print(message)
 }
 ```
 
-**❌ FORBIDDEN - Field Access on Union Types:**
+Operations (see [Iterators and Iteration](0010-LoopConstructsAndFunctionalIterators.md) for full signatures):
+
 ```osprey
-type Shape = Circle { radius: int } 
-           | Rectangle { width: int, height: int }
+let doubled  = numbers |> map(x => x * 2)
+let evens    = numbers |> filter(x => x % 2 == 0)
+let total    = numbers |> fold(initial: 0, function: (acc, x) => acc + x)
+let combined = numbers + [6, 7, 8]                       // concatenation produces a new list
+numbers |> forEach(x => print(toString(x)))
+```
 
-let shape = Circle { radius: 5 }
+Patterns:
 
-// ERROR: Cannot access fields on union type
-let radius = shape.radius     // Compilation error
-
-// CORRECT: Pattern match on union type first
-let area = match shape {
-    Circle { radius } => 3.14 * radius * radius
-    Rectangle { width, height } => width * height
+```osprey
+fn classify(xs: List<int>) -> string = match xs {
+    []                 => "empty"
+    [single]           => "one"
+    [first, second]    => "two"
+    [head, ...tail]    => "many starting with ${head}"
 }
 ```
 
-**Compilation Errors:**
+List comprehensions and head/tail destructuring:
+
 ```osprey
-// ERROR: Unknown field
-let invalid = Point { x: 10, z: 30 }  // 'z' not defined in Point
-
-// ERROR: Missing required field  
-let incomplete = Person { name: "Alice" }  // Missing 'age' and 'active'
-
-// ERROR: Type mismatch
-let wrongType = Point { x: "ten", y: 20 }  // 'x' expects int, got string
-
-// ERROR: Field access on non-record type
-let num = 42
-let invalid = num.x  // Cannot access field on non-record type
-
-// ERROR: Cannot assign to fields (immutable)
-let counter = Counter { value: 0 }
-counter.value = 5    // Compilation error
-
-// CORRECT: Create new instance with updated value
-let newCounter = counter { value: 5 }
-```
-
-#### Collection Types (List and Map)
-
-Osprey provides immutable, persistent collections with compile-time safety and zero-cost abstractions.
-
-##### List<T> - Immutable Sequential Collections
-
-**Properties:**
-- Complete immutability with structural sharing
-- Type-safe with homogeneous elements
-- Bounds-checked access returns `Result<T, IndexError>`
-- Compiled to efficient native code
-
-**List Literal Syntax:**
-```osprey
-// Homogeneous lists with complete type inference - NO ANNOTATIONS NEEDED
-let numbers = [1, 2, 3, 4, 5]           // List<int> - inferred from elements
-let names = ["Alice", "Bob", "Charlie"]  // List<string> - inferred from elements
-let flags = [true, false, true]         // List<bool> - inferred from elements
-
-// Empty lists only need annotation when inference is impossible
-let empty = []                          // ERROR: Cannot infer element type
-let empty: List<int> = []               // Explicit annotation required for empty lists
-let strings: List<string> = []          // Explicit annotation required for empty lists
-
-// BUT: Empty lists can be inferred from usage context
-fn processNumbers(nums: List<int>) = fold(0, (+), nums)
-let result = processNumbers([])         // [] inferred as List<int> from function signature
-```
-
-**Type-Safe Array Access:**
-```osprey
-let scores = [85, 92, 78, 96, 88]
-
-// Array access returns Result for safety
-match scores[0] {
-    Success { value } => print("First score: ${toString(value)}")
-    Error { message } => print("Index error: ${message}")
-}
-
-// Bounds checking prevents runtime errors
-match scores[10] {  // Out of bounds
-    Success { value } => print("Never reached")
-    Error { message } => print("Index out of bounds")  // This executes
-}
-```
-
-**Functional Operations:**
-```osprey
-// Core functional list operations
-let doubled = map(x => x * 2, numbers)        // [2, 4, 6, 8, 10]
-let evens = filter(x => x % 2 == 0, numbers)  // [2, 4]
-let sum = fold(0, (acc, x) => acc + x, numbers)  // 15
-
-// List concatenation (creates new list)
-let combined = numbers + [6, 7, 8]            // [1, 2, 3, 4, 5, 6, 7, 8]
-
-// forEach for side effects
-forEach(x => print(toString(x)), numbers)    // Prints: 1, 2, 3, 4, 5
-```
-
-**Pattern Matching with Lists:**
-```osprey
-fn processScores(scores: List<int>) -> string = match scores {
-    [] => "No scores"
-    [single] => "Single score: ${toString(single)}"
-    [first, second] => "Two scores: ${toString(first)}, ${toString(second)}"
-    [head, ...tail] => "Multiple scores, first: ${toString(head)}"
-}
-
-// Advanced list matching
-fn analyzeGrades(grades: List<string>) -> string = match grades {
-    ["A", ...rest] => "Starts with A+ performance"
-    [..._, "F"] => "Ends with failing grade" 
-    grades when length(grades) > 10 => "Large class"
-    _ => "Regular class"
-}
-```
-
-**List Construction and Deconstruction:**
-```osprey
-// List builders and comprehensions
-let squares = [x * x for x in range(1, 5)]     // [1, 4, 9, 16, 25]
-let filtered = [x for x in numbers if x > 3]   // [4, 5]
-
-// Destructuring assignment
-let [first, second, ...rest] = [1, 2, 3, 4, 5]
-// first = 1, second = 2, rest = [3, 4, 5]
-
-// Head/tail decomposition
+let squares  = [x * x for x in range(start: 1, end: 5)]   // [1, 4, 9, 16, 25]
+let filtered = [x for x in numbers if x > 3]
 let [head, ...tail] = numbers
-// head = 1, tail = [2, 3, 4, 5]
 ```
 
-##### Map<K, V> - Immutable Key-Value Collections
+### `Map<K, V>`
 
-**Core Properties:**
-- **Immutable**: Maps cannot be modified after creation
-- **Persistent Structure**: Efficient updates create new maps with structural sharing
-- **Type Safety**: Keys type K, values type V with compile-time verification
-- **Hash-Based**: O(log n) lookup, insert, and delete operations
-- **Functional Operations**: map, filter, fold operations preserve immutability
+Immutable, persistent. Lookup, insert, and remove are O(log n) and return new maps.
 
-**Map Literal Syntax:**
 ```osprey
-// Map literals with complete type inference - NO ANNOTATIONS NEEDED
 let ages = {
-    "Alice": 25,
-    "Bob": 30, 
+    "Alice":   25,
+    "Bob":     30,
     "Charlie": 35
-}  // Map<string, int> - inferred from key/value types
+}                                                 // Map<string, int>
 
-let settings = {
-    "debug": true,
-    "timeout": 5000,
-    "retries": 3
-}  // Map<string, int | bool> - Union type inferred from mixed values
+let scores: Map<string, int> = {}                 // empty needs annotation
 
-// Empty maps only need annotation when inference is impossible
-let empty = {}                          // ERROR: Cannot infer key/value types
-let scores: Map<string, int> = {}       // Explicit annotation required for empty maps
-let flags: Map<int, bool> = {}          // Explicit annotation required for empty maps
-
-// BUT: Empty maps can be inferred from usage context
-fn processAges(ageMap: Map<string, int>) = length(ageMap)
-let result = processAges({})            // {} inferred as Map<string, int> from function signature
-```
-
-**Safe Map Access:**
-```osprey
-// Map access returns Result for safety
 match ages["Alice"] {
-    Success { value } => print("Alice is ${toString(value)} years old")
-    Error { message } => print("Alice not found")
+    Success { value }   => print(toString(value))
+    Error   { message } => print(message)
 }
 
-// Checking for key existence
-let hasAlice = contains(ages, "Alice")  // bool
-let ageCount = length(ages)            // int
+let hasAlice = contains(map: ages, key: "Alice")
+let n        = length(ages)
 ```
 
-**Functional Map Operations:**
+Operations:
+
 ```osprey
-// Transform values while preserving keys
-let incrementedAges = mapValues(age => age + 1, ages)
-// { "Alice": 26, "Bob": 31, "Charlie": 36 }
-
-// Transform keys while preserving values  
-let uppercased = mapKeys(name => toUpperCase(name), ages)
-// { "ALICE": 25, "BOB": 30, "CHARLIE": 35 }
-
-// Filter key-value pairs
-let thirties = filter((name, age) => age >= 30, ages)
-// { "Bob": 30, "Charlie": 35 }
-
-// Fold over key-value pairs
-let totalAge = fold(0, (acc, name, age) => acc + age, ages)  // 90
+let bumped     = ages |> mapValues(age => age + 1)
+let upper      = ages |> mapKeys(name => toUpperCase(name))
+let thirties   = ages |> filter((name, age) => age >= 30)
+let totalAge   = ages |> fold(initial: 0, function: (acc, name, age) => acc + age)
+let withDave   = ages + { "Dave": 28 }
+let updated    = ages { "Alice": 26 }                       // single-key update
+let withoutBob = removeKey(map: ages, key: "Bob")
 ```
 
-**Map Updates (Non-destructive):**
+Patterns:
+
 ```osprey
-// Add new key-value pairs (creates new map)
-let withDave = ages + { "Dave": 28 }
-// { "Alice": 25, "Bob": 30, "Charlie": 35, "Dave": 28 }
-
-// Update existing values (creates new map)
-let updated = ages { "Alice": 26 }  // Only Alice's age changes
-// { "Alice": 26, "Bob": 30, "Charlie": 35 }
-
-// Multiple updates
-let multiUpdate = ages { 
-    "Alice": 26,
-    "Bob": 31,
-    "Eve": 22  // New entry
-}
-
-// Remove keys (creates new map)
-let withoutBob = removeKey(ages, "Bob")
-// { "Alice": 25, "Charlie": 35 }
-```
-
-**Pattern Matching with Maps:**
-```osprey
-fn analyzeAges(people: Map<string, int>) -> string = match people {
-    {} => "No people"
-    { "Alice": age } => "Only Alice, age ${toString(age)}"
-    { "Alice": aliceAge, "Bob": bobAge } => "Alice and Bob present"
-    people when length(people) > 5 => "Large group"
-    _ => "Regular group"
-}
-
-// Advanced map patterns
-fn checkTeam(team: Map<string, string>) -> bool = match team {
-    { "lead": _, "dev": _, "tester": _ } => true  // Has all key roles
-    { "lead": name, ...others } when length(others) >= 2 => true  // Lead plus 2+ others
-    _ => false  // Incomplete team
+fn analyze(p: Map<string, int>) -> string = match p {
+    {}                                       => "none"
+    { "Alice": age }                         => "only Alice (${age})"
+    { "Alice": _, "Bob": _ }                 => "Alice and Bob"
+    p when length(p) > 5                     => "large"
+    _                                        => "other"
 }
 ```
 
-**Collection Interoperability:**
+Conversions:
+
 ```osprey
-// Convert between collections
-let names = keys(ages)        // List<string> = ["Alice", "Bob", "Charlie"]  
-let ageList = values(ages)    // List<int> = [25, 30, 35]
-let pairs = entries(ages)     // List<(string, int)> = [("Alice", 25), ...]
-
-// Build map from lists
-let nameList = ["Alice", "Bob", "Charlie"]
-let ageList = [25, 30, 35]
-let peopleMap = zipToMap(nameList, ageList)  // Map<string, int>
-
-// Group by operation
-let students = [
-    { name: "Alice", grade: "A" },
-    { name: "Bob", grade: "B" },  
-    { name: "Charlie", grade: "A" }
-]
-let byGrade = groupBy(student => student.grade, students)
-// Map<string, List<Student>> = { "A": [Alice, Charlie], "B": [Bob] }
+let names    = keys(ages)                                       // List<string>
+let agesList = values(ages)                                     // List<int>
+let pairs    = entries(ages)                                    // List<(string, int)>
+let m        = zipToMap(keys: names, values: agesList)
+let byGrade  = groupBy(items: students, function: s => s.grade) // Map<string, List<Student>>
 ```
 
-**Performance:**
+### Performance
 
-List operations: O(1) element access, O(n) concatenation and functional operations.
-Map operations: O(log n) lookup/insert/update, O(n) iteration.
-
-Memory management uses structural sharing for efficiency, deterministic cleanup without garbage collection, and stack allocation for small collections.
-
-Safety: bounds checking prevents overflows, immutability prevents race conditions, type safety enforced throughout.
-
+`List<T>`: O(1) indexed access, O(n) concatenation and bulk transforms. `Map<K, V>`: O(log n) lookup/insert/update, O(n) iteration. Both use structural sharing; small collections may be stack-allocated.
 
 ## Built-in Error Types
 
-- `MathError`: For arithmetic operations (DivisionByZero, Overflow, Underflow)
-- `ParseError`: For string parsing operations  
-- `IndexError`: For list/string indexing operations (OutOfBounds)
-- `Success`: Successful result wrapper
+| Type          | Used by                                              |
+| ------------- | ---------------------------------------------------- |
+| `MathError`   | Arithmetic (`DivisionByZero`, `Overflow`, `Underflow`)|
+| `ParseError`  | String parsing                                       |
+| `IndexError`  | List and string indexing (`OutOfBounds`)             |
+| `StringError` | String operations that can fail (`length`, `substring`, `contains`) |
+| `ChannelError`| Channel send/recv                                    |
 
-## Type Inference Examples
+`Success` and `Error` are the constructors of `Result<T, E>` (see [Error Handling](0013-ErrorHandling.md)).
 
-#### Hindley-Milner Function Inference
+## The `any` Type
 
-**Complete Type Inference**: Both parameter and return types can be omitted when inferrable through Hindley-Milner constraint solving:
+`any` is an erased type. It exists so a function may receive a value whose type is not known statically — for example, parsed JSON or a foreign-function return value. Direct use of an `any` value is forbidden; the value must be narrowed by `match` first.
 
-##### Hindley-Milner Inference Examples
-
-**✅ POLYMORPHIC INFERENCE (No Type Annotations Required):**
-```osprey
-// Identity function - fully polymorphic
-fn identity(x) = x              // Infers: <T>(T) -> T
-
-// Arithmetic functions
-fn add(a, b) = a + b           // Infers: (int, int) -> Result<int, MathError>
-fn increment(x) = x + 1        // Infers: (int) -> Result<int, MathError>
-fn addFloats(a, b) = a + b     // Infers: (float, float) -> Result<float, MathError>
-fn divide(x, y) = x / y        // Infers: (int, int) -> Result<float, MathError> (auto-promotes to float)
-
-// String operations  
-fn concat(s1, s2) = s1 + s2    // Infers: (string, string) -> string
-
-// Boolean operations
-fn negate(x) = !x              // Infers: (bool) -> bool
-
-// Field access polymorphism
-fn getX(p) = p.x               // Infers: <T>(Point<T, _>) -> T
-fn getValue(c) = c.value       // Infers: <T>(Container<T, _>) -> T
-
-// Higher-order functions
-fn apply(f, x) = f(x)          // Infers: <A, B>((A) -> B, A) -> B
-fn compose(f, g) = fn(x) = f(g(x))  // Infers: <A, B, C>((B) -> C, (A) -> B) -> (A) -> C
-```
-
-**✅ MONOMORPHIC USAGE (Types Specialized at Call Sites):**
-```osprey
-// Same identity function used with different types
-let intResult = identity(42)        // identity<int>
-let stringResult = identity("test") // identity<string>
-let boolResult = identity(true)     // identity<bool>
-
-// Field accessors specialized by usage
-let intPoint = Point { x: 10, y: 20 }
-let stringPoint = Point { x: "a", y: "b" }
-
-let intX = getX(intPoint)           // getX<int>
-let stringX = getX(stringPoint)     // getX<string>
-```
-
-#### Constraint-Based Type Inference
-
-**Unification Rules**: Osprey's Hindley-Milner implementation uses constraint unification to solve type equations:
-
-**✅ CONSTRAINT SOLVING EXAMPLES:**
-```osprey
-// Function with multiple constraints
-fn processData(item, transform) = transform(item.value)
-// Constraints:
-// - item must have field 'value' of type α
-// - transform must be function (α) -> β  
-// - return type is β
-// Solution: <α, β>(Container<α>, (α) -> β) -> β
-
-// Recursive constraint solving
-fn chain(f, g, x) = f(g(x))
-// Constraints:
-// - g must be function (α) -> β
-// - f must be function (β) -> γ
-// - x has type α
-// - return type is γ
-// Solution: <α, β, γ>((β) -> γ, (α) -> β, α) -> γ
-```
-
-**✅ POLYMORPHIC GENERALIZATION:**
-```osprey
-// Generic data constructors
-fn makePair(x, y) = Pair { first: x, second: y }
-// Infers: <A, B>(A, B) -> Pair<A, B>
-
-fn makePoint(a, b) = Point { x: a, y: b }
-// Infers: <T>(T, T) -> Point<T, T>
-
-// Generic extractors
-fn getFirst(p) = p.first
-// Infers: <A, B>(Pair<A, B>) -> A
-
-fn getSecond(p) = p.second  
-// Infers: <A, B>(Pair<A, B>) -> B
-```
-
-#### Hindley-Milner Implementation Examples
-
-**✅ COMPLETE TYPE INFERENCE (All Types Derived):**
-```osprey
-// Polymorphic identity - no annotations needed
-fn identity(x) = x              // <T>(T) -> T
-
-// Arithmetic with constraint propagation
-fn add(a, b) = a + b           // (int, int) -> Result<int, MathError>
-fn multiply(x, y) = x * y      // (int, int) -> Result<int, MathError>
-
-// String operations
-fn greet(name) = "Hello, " + name  // (string) -> string
-
-// Record construction and access
-fn makeUser(n, a) = User { name: n, age: a }  // (string, int) -> User
-fn getName(u) = u.name         // (User) -> string
-
-// Higher-order functions
-fn twice(f, x) = f(f(x))       // <T>((T) -> T, T) -> T
-fn map(f, list) = [f(x) for x in list]  // <A, B>((A) -> B, List<A>) -> List<B>
-```
-
-**✅ MONOMORPHIZATION AT USAGE SITES:**
-```osprey
-// Same polymorphic functions, different instantiations
-let id1 = identity(42)          // identity<int>
-let id2 = identity("test")      // identity<string> 
-let id3 = identity(true)        // identity<bool>
-
-// Function used in different contexts
-let intTwice = twice(increment, 5)      // twice<int>
-let stringTwice = twice(greet, "World")  // twice<string>
-```
-
-**❌ INFERENCE LIMITATIONS (Explicit Types Required):**
-```osprey
-// Ambiguous conditional requires annotation
-fn conditional(flag, a, b) -> T = if flag then a else b  // T must be specified
-
-// External function calls may need hints
-fn process(data) -> R = externalFunction(data)  // R may need annotation
-
-// Complex constraints may require explicit polymorphic declaration
-fn complex<T>(x: T, pred: (T) -> bool) -> Option<T> = 
-    if pred(x) then Some(x) else None
-```
-
-#### Type Inference Benefits
-
-- **Zero annotations needed**: Write polymorphic functions without type signatures
-- **Maximum reusability**: Functions work with all compatible types
-- **Compile-time safety**: All type errors caught before execution
-- **Principal types**: Every expression has a unique most general type
-
-#### Record Type Structural Equivalence
-
-Osprey's Hindley-Milner implementation uses structural equivalence based on field names only, not field order.
+### Forbidden Operations
 
 ```osprey
-// These record types are structurally equivalent
-type PersonA = { name: string, age: int }
-type PersonB = { age: int, name: string }  // Different order, same structure
-
-fn getName(record) = record.name  // Infers: ∀α. {name: string, ...α} -> string
+fn processAny(v: any) -> int = v + 1                       // ❌ direct arithmetic
+fn getLength(v: any) -> int = v.length                     // ❌ direct field access
+let n: int = someAnyFunction()                             // ❌ implicit conversion
+fn callIt(v: any) = someFunction(v)                        // ❌ pass to typed parameter
+let s = toString(v)              // where v: any            // ❌ implicit conversion
 ```
 
-**Unification Algorithm:**
-Record types unify if and only if they have the same field names with matching types. Field order is irrelevant:
+Each of these produces a compilation error.
 
-```
-unify(RecordType1, RecordType2) :=
-    if field_names(RecordType1) ≠ field_names(RecordType2) then FAIL
-    else ∀ field_name ∈ field_names(RecordType1):
-        unify(field_type(RecordType1, field_name), field_type(RecordType2, field_name))
-```
-
-#### Polymorphic Type Variables vs Any Type
-
-Hindley-Milner infers polymorphic type variables (α, β, γ), not the `any` type:
+### Required Form
 
 ```osprey
-fn identity(x) = x           // Infers: <T>(T) -> T
-fn apply(f, x) = f(x)        // Infers: <A, B>((A) -> B, A) -> B
-```
-
-The `any` type requires explicit declaration:
-
-```osprey
-fn parseValue(input: string) -> any = processInput(input)
-```
-
-Polymorphic type variables are instantiated at call sites and checked statically at compile time.
-
-#### Hindley-Milner Constraint Resolution
-
-**Automatic Type Resolution**: The compiler uses constraint solving to resolve all type variables:
-
-```osprey
-// ✅ FULLY INFERRED: No annotations needed
-fn greet(name) = "Hello, " + name    // String constraint from concatenation
-fn formatScore(name, score) = "${name}: ${score}"  // String interpolation context
-fn calculate(x, y) = x * y + 1       // Arithmetic constraints
-
-// ✅ POLYMORPHIC RESOLUTION: Generic across multiple types
-fn wrap(value) = Container { data: value }  // <T>(T) -> Container<T>
-fn unwrap(container) = container.data       // <T>(Container<T>) -> T
-
-// ✅ HIGHER-ORDER INFERENCE: Function parameters inferred
-fn applyToList(func, items) = [func(x) for x in items]
-// Infers: <A, B>((A) -> B, List<A>) -> List<B>
-```
-
-**Manual Annotation (When Desired)**: Explicit types can be added for documentation:
-```osprey
-fn greet(name: string) -> string = "Hello, " + name  // Explicit for clarity
-fn identity<T>(x: T) -> T = x                        // Explicit polymorphism
-```
-
-## Type Safety and Explicit Typing
-
-**CRITICAL RULE**: Osprey is fully type-safe with no exceptions.
-
-#### Mandatory Type Safety
-- **No implicit type conversions** - all type mismatches are compile-time errors
-- **No runtime type errors** - all type issues caught at compile time
-- **No panics or exceptions** - all error conditions must be handled explicitly
-
-## Any Type Handling and Pattern Matching Requirement
-
-🔄 **IMPLEMENTATION STATUS**: `any` type validation is partially implemented. Basic validation for function arguments is working, but complete pattern matching enforcement is in progress.
-
-Osprey provides the `any` type for maximum flexibility, but enforces strict access rules to maintain type safety. Direct access to `any` types is forbidden in most contexts - all `any` values must be accessed through pattern matching to extract their actual types.
-
-#### Forbidden Operations on `any` Types
-
-The following operations on `any` types will result in compilation errors:
-
-1. **Direct variable access** - `any` variables cannot be used directly
-2. **Function arguments** - `any` values cannot be passed to functions expecting concrete types  
-3. **Field access** - Properties cannot be accessed directly on `any` types
-4. **Implicit conversions** - `any` cannot be implicitly converted to other types
-
-#### Legal Operations on `any` Types
-
-**Arithmetic operations** with `any` types are explicitly allowed and return `Result` types:
-
-```osprey
-let x: any = 42
-let result = x + 5  // Returns Result<Int, ArithmeticError>
-
-let y: any = "hello" 
-let sum = y + 10    // Returns Result<Int, TypeError>
-```
-
-These operations are safe because they return `Result` types that encapsulate potential errors, maintaining type safety while allowing flexible computation.
-
-#### Pattern Matching Requirement
-
-**Pattern Matching Requirement:**
-All `any` values must be accessed through pattern matching to extract their actual types (see [Pattern Matching](0008-PatternMatching.md) for complete syntax and examples).
-
-#### Direct Access Compilation Errors
-
-**❌ FORBIDDEN - Direct Access:**
-```osprey
-fn processAny(value: any) -> int = value + 1
-// ERROR: cannot use 'any' type directly in arithmetic operation
-
-fn getLength(value: any) -> int = value.length
-// ERROR: cannot access field on 'any' type without pattern matching
-
-let result: int = someAnyFunction()
-// ERROR: cannot assign 'any' to 'int' without pattern matching
-
-fn callFunction(value: any) = someFunction(value)
-// ERROR: cannot pass 'any' type to function expecting specific type
-
-let converted = toString(value)  // where value: any
-// ERROR: cannot implicitly convert 'any' to expected parameter type
-```
-
-**✅ REQUIRED - Pattern Matching:**
-Use pattern matching to safely extract values from `any` types (complete examples in [Pattern Matching](0008-PatternMatching.md)).
-
-#### Function Return Type Handling
-
-Functions returning `any` types require immediate pattern matching (see [Pattern Matching](0008-PatternMatching.md)).
-
-#### Type Annotation Pattern Syntax
-
-The `:` operator is used for type annotation in patterns:
-- `value: Int` - Matches if value is an Int, binds to `value`
-- `text: String` - Matches if value is a String, binds to `text`
-- `flag: Bool` - Matches if value is a Bool, binds to `flag`
-- `{ name, age }` - Structural match on any type with name and age fields
-- `person: { name, age }` - Named structural match, binds whole object and fields
-- `_` - Wildcard matches any remaining type
-
-#### Compilation Error Messages
-
-The compiler **MUST** emit these specific errors for `any` type violations:
-
-```osprey
-// Direct arithmetic operation
-"cannot use 'any' type directly in arithmetic operation - pattern matching required"
-
-// Direct field access
-"cannot access field on 'any' type without pattern matching"
-
-// Direct assignment to typed variable
-"cannot assign 'any' to 'TYPE' without pattern matching"
-
-// Direct function argument
-"cannot pass 'any' type to function expecting 'TYPE' - pattern matching required"
-
-// Implicit conversion attempt
-"cannot implicitly convert 'any' to 'TYPE' - use pattern matching to extract specific type"
-
-// Variable access on any
-"cannot access variable of type 'any' directly - pattern matching required"
-
-// Missing pattern match arm
-"pattern matching on 'any' type must handle all possible types or include wildcard"
-
-// Impossible type patterns
-"pattern 'TYPE' is not a possible type for expression of documented types [TYPE1, TYPE2, ...]"
-
-// Unreachable patterns
-"unreachable pattern: 'TYPE' cannot occur based on context analysis"
-```
-
-#### Exhaustiveness Checking for Any Types
-
-Pattern matching on `any` types **MUST** be exhaustive:
-- Handle all expected types, OR
-- Include a wildcard pattern (`_`) to handle unexpected types
-
-```osprey
-// Non-exhaustive (ERROR)
-match anyValue 
-    value: Int => processInt(value)
-    value: String => processString(value)
-    // ERROR: missing wildcard or Bool case
-
-// Exhaustive (CORRECT)
-match anyValue 
-    value: Int => processInt(value)
-    value: String => processString(value)
-    _ => handleOther()
-```
-
-#### Default Wildcard Behavior for Any Types
-
-The wildcard pattern (`_`) in `any` type matching preserves the `any` type:
-
-```osprey
-// Wildcard returns any type
-let result = match someAnyValue 
-    value: Int => processInt(value)    // Returns specific type
-    value: String => processString(value)  // Returns specific type
-    _ => someAnyValue  // Returns any type (unchanged)
-// result type: any (due to wildcard arm)
-
-// To avoid any type in result, handle all expected cases explicitly
-let result = match someAnyValue 
-    value: Int => processInt(value)
-    value: String => processString(value)
-    _ => defaultInt()  // Convert to specific type
-// result type: Int (all arms return Int)
-```
-
-#### Type Constraint Checking
-
-The compiler **MUST** validate that pattern types are actually possible for the value being matched:
-
-**✅ VALID - Realistic Type Patterns:**
-```osprey
-// Function known to return Int or String
-extern fn parseIntOrString(input: string) -> any
-
-match parseIntOrString("42") 
-    value: Int => value + 1
-    value: String => length(value)
-    _ => 0  // Valid: handles any unexpected types
-```
-
-**❌ INVALID - Impossible Type Patterns:**
-```osprey
-// Function documented to only return Int or String
-extern fn parseIntOrString(input: string) -> any
-
-match parseIntOrString("42") 
-    value: Int => value + 1
-    value: String => length(value)
-    value: Bool => if value then 1 else 0  // ERROR: Bool not possible
-    _ => 0
-// ERROR: pattern 'Bool' is not a possible type for function 'parseIntOrString'
-```
-
-#### Context-Aware Type Validation
-
-When the compiler has information about possible types (from documentation, extern declarations, or analysis), it **MUST** enforce realistic pattern matching:
-
-```osprey
-// Extern function with documented return types
-extern fn getUserInput() -> any  // Documentation: returns Int | String | Bool only
-
-// VALID: Only realistic types
-match getUserInput() {
-    value: Int => processInt(value)
-    value: String => processString(value) 
-    value: Bool => processBool(value)
-    _ => handleUnexpected()  // Still allowed for safety
-}
-
-// INVALID: Unrealistic types
-match getUserInput() {
-    value: Int => processInt(value)
-    value: Array<String> => processArray(value)  // ERROR: Array not documented
-    _ => handleOther()
-}
-// ERROR: pattern 'Array<String>' is not a documented return type for 'getUserInput'
-```
-
-#### Compilation Errors for Impossible Types
-
-```osprey
-"pattern 'TYPE' is not a possible type for expression of documented types [TYPE1, TYPE2, ...]"
-"unreachable pattern: 'TYPE' cannot occur based on context analysis"
-"pattern matching includes impossible type 'TYPE' - check function documentation"
-```
-
-#### Performance and Safety Characteristics
-
-- **Compile-time type checking**: Pattern matching enables compile-time verification
-- **Zero runtime cost**: Type patterns compiled to efficient type tags
-- **Memory safety**: No type confusion or invalid casts possible
-- **Explicit control**: Developers must explicitly handle all type cases
-
-#### Type Annotation Requirements
-When the compiler cannot infer types, explicit type annotations are **REQUIRED**:
-
-```osprey
-// Type annotations required when inference is ambiguous
-fn complexOperation(data: String, count: Int) = processData(data, count)
-
-// Generic functions require type parameters
-fn parseValue<T>(input: String) -> Result<T, ParseError> = ...
-
-// Union types with fields require explicit typing
-type Result<T, E> = Ok { value: T } | Err { error: E }
-```
-
-#### Compilation Errors for Type Ambiguity
-The compiler **MUST** emit errors when:
-1. Function parameter types cannot be inferred from usage
-2. Return types are ambiguous
-3. Variable types cannot be determined from initializers
-4. Generic type parameters are not specified
-
-#### Error Handling Requirements
-- **No exceptions or panics** - all failing operations return Result types
-- **Explicit error handling** - all Result types must be pattern matched
-- **Safe arithmetic** - operations like division must return Result<T, Error>
-
-```osprey
-// REQUIRED: Safe division that cannot panic
-fn safeDivide(a: Int, b: Int) -> Result<Int, MathError> = match b {
-  0 => Err { error: DivisionByZero }
-  _ => Ok { value: a / b }
-}
-
-// REQUIRED: All results must be handled
-let result = safeDivide(a: 10, b: 2)
-match result {
-  Ok { value } => print("Result: ${value}")
-  Err { error } => handleError(error)
+fn process(v: any) -> int = match v {
+    n: int    => n + 1
+    s: string => length(s)
+    _         => 0
 }
 ```
 
-#### Type-Level Validation
+Pattern syntax (`name: Type`, `name: { fields }`, `{ fields }`, `_`) is defined in [Pattern Matching](0007-PatternMatching.md).
 
-**CRITICAL**: When a type has a WHERE validation function, the type constructor **ALWAYS** returns `Result<T, String>` instead of the type directly.
+### Exhaustiveness
 
-**Validation Syntax:**
-```
-type_validation := 'where' function_name
-```
+A `match` on `any` must either cover every type the value may take or include a wildcard `_`:
 
-**Examples:**
 ```osprey
-// Unconstrained type - direct construction
-type Point = { x: Int, y: Int }
-let point = Point { x: 10, y: 20 }  // Returns Point directly
-
-// Type with validation function - returns Result type
-type Product = { 
-    name: String,
-    price: Int
-} where validateProduct
-
-fn validateProduct(product: Product) -> Result<Product, String> = match product.name {
-    "" => Error("Product name cannot be empty")
-    _ => match product.price {
-        0 => Error("Price must be positive")
-        _ => Success(product)
-    }
-}
-
-let product = Product { name: "Widget", price: 100 }  // Returns Result<Product, String>
-
-// Pattern matching required for validated types
-match product {
-    Success { value } => {
-        print("Product: ${value.name}")
-        print("Price: ${value.price}")
-    }
-    Error { message } => {
-        print("Validation failed: ${message}")
-    }
-}
-
-// Invalid validation fails at construction
-let invalid = Product { name: "", price: -10 }  // Returns Error variant
-match invalid {
-    Success { value } => print("This won't execute")
-    Error { message } => print("Expected error: ${message}")
+match v {
+    n: int    => processInt(n)
+    s: string => processString(s)
+    _         => handleOther()
 }
 ```
 
-**Field Access Rules:**
-- **Unvalidated types**: Direct field access allowed (`point.x`)
-- **Validated types**: Field access **ONLY** after pattern matching on Result
+A wildcard arm that returns the matched value preserves the `any` type; to escape `any`, every arm (including the wildcard) must return the same concrete type.
 
-**Compilation Errors:**
+### Compiler Errors
+
+The compiler emits the following message strings on `any`-type misuse:
+
+```
+cannot use 'any' type directly in arithmetic operation - pattern matching required
+cannot access field on 'any' type without pattern matching
+cannot assign 'any' to 'TYPE' without pattern matching
+cannot pass 'any' type to function expecting 'TYPE' - pattern matching required
+cannot implicitly convert 'any' to 'TYPE' - use pattern matching to extract specific type
+cannot access variable of type 'any' directly - pattern matching required
+pattern matching on 'any' type must handle all possible types or include wildcard
+```
+
+### Documented Type Sets
+
+When the compiler has information about which types an `any`-returning function may produce — for example, from an `extern` declaration or annotation — it rejects patterns that match impossible types and unreachable patterns:
+
+```
+pattern 'TYPE' is not a possible type for expression of documented types [TYPE1, TYPE2, ...]
+unreachable pattern: 'TYPE' cannot occur based on context analysis
+pattern matching includes impossible type 'TYPE' - check function documentation
+```
+
+## Type Annotation Requirements
+
+Annotations are required when the compiler cannot infer a type:
+
+- An empty literal (`[]`, `{}`) with no contextual type.
+- A function whose return type is ambiguous (for example, a value returned from an `extern`).
+- A polymorphic function whose type variables are not constrained by any argument.
+
 ```osprey
-// ERROR: Cannot access field on Result type
-let name = product.name  // Compilation error - pattern matching required
-
-// CORRECT: Field access after unwrapping
-match product {
-    Success { value } => print("Name: ${value.name}")  // Valid field access
-    Error { message } => print("Error: ${message}")
-}
+let xs: List<int> = []
+fn parseValue<T>(input: string) -> Result<T, ParseError> = ...
 ```
 
-## Type Compatibility
-
-- Pattern matching for type discrimination
-- Union types for representing alternatives
-- Result types for error handling instead of exceptions
+The compiler emits an error in each case where inference is ambiguous; explicit annotations resolve them.

--- a/compiler/spec/0005-FunctionCalls.md
+++ b/compiler/spec/0005-FunctionCalls.md
@@ -41,21 +41,10 @@ let sum = add(10, y: 20)  // Compilation error
 let result = multiply(5, b: 3)  // Compilation error
 ```
 
-## Compilation Rules
+## Rules
 
-1. **Zero parameters**: Called with empty parentheses `()`
-2. **Single parameter**: May use positional or named argument
-3. **Multiple parameters**: All arguments must be named
-4. **Argument order**: Named arguments are reordered to match parameter declaration order during compilation
+1. Zero parameters: empty parentheses, `f()`.
+2. One parameter: positional or named.
+3. Two or more parameters: every argument must be named. Mixing positional and named arguments is a compilation error.
 
-## Rationale
-
-Named arguments improve readability and prevent argument order errors in multi-parameter functions:
-
-```osprey
-// Clear intent with named arguments
-httpGet(clientID: client, path: "/users", headers: "")
-
-// Unclear with positional arguments (forbidden)
-httpGet(client, "/users", "")  // What does "" mean?
-```
+Argument order at the call site is independent of declaration order; the compiler reorders by name.

--- a/compiler/spec/0006-StringInterpolation.md
+++ b/compiler/spec/0006-StringInterpolation.md
@@ -74,9 +74,3 @@ Supported escape sequences:
 - `\"` - Double quote
 - `\${` - Literal `${` (prevents interpolation)
 
-## Implementation
-
-Interpolated strings compile to efficient buffer operations:
-1. Allocate a buffer (`alloca [1024 x i8]`)
-2. Use `sprintf` with appropriate format specifiers (`%s`, `%ld`, etc.)
-3. Return the formatted string for use in expressions

--- a/compiler/spec/0007-PatternMatching.md
+++ b/compiler/spec/0007-PatternMatching.md
@@ -1,19 +1,8 @@
-8. [Pattern Matching](0008-PatternMatching.md)
-   - [Basic Patterns](#basic-patterns)
-   - [Union Type Patterns](#union-type-patterns)
-   - [Wildcard Patterns](#wildcard-patterns)
-   - [Type Annotation Patterns](#type-annotation-patterns)
-       - [Type Annotation Patterns](#type-annotation-patterns)
-       - [Anonymous Structural Matching](#anonymous-structural-matching)
-       - [Named Structural Matching](#named-structural-matching)
-       - [Mixed Type and Structural Patterns](#mixed-type-and-structural-patterns)
-   - [Match Expression Type Safety Rules](#match-expression-type-safety-rules)
+# Pattern Matching
 
-## Pattern Matching
+`match` is the only branching construct in Osprey. Record patterns are matched structurally by field name, not by field order. See [Type System](0004-TypeSystem.md) for type unification rules.
 
-Pattern matching in Osprey uses field name matching only. Record type patterns are based on structural equivalence by field names, not field order. See [Type System](0004-TypeSystem.md#hindley-milner-type-inference) for complete type unification rules.
-
-### Basic Patterns
+## Basic Patterns
 
 ```osprey
 let result = match value {
@@ -25,12 +14,14 @@ let result = match value {
 
 ## Union Type Patterns
 
+A union pattern names the variant. Variants with fields are destructured using `{ field, ... }`; variants without fields are matched by name alone.
+
 ```osprey
-type Option = Some { value: Int } | None
+type Option = Some { value: int } | None
 
 let message = match option {
-    Some x => "Value: " + toString(x.value)
-    None => "No value"
+    Some { value } => "Value: " + toString(value)
+    None           => "No value"
 }
 ```
 
@@ -48,266 +39,102 @@ let category = match score {
 
 ## Type Annotation Patterns
 
-Type annotation patterns use the `:` operator to match values of specific types. This is **REQUIRED** for `any` types.
+A pattern of the form `name: type` matches when the value has the named type and binds it. This is the required form for narrowing an `any` value.
 
-```
-type_pattern := ID ':' type
-structural_pattern := ID ':' '{' field_list '}'
-anonymous_structural_pattern := '{' field_list '}'
-constructor_pattern := ID ('(' pattern (',' pattern)* ')')?
-variable_pattern := ID
-wildcard_pattern := '_'
+```ebnf
+typePattern              ::= ID ":" type
+structuralPattern        ::= ID ":" "{" fieldList "}"
+anonymousStructuralPattern ::= "{" fieldList "}"
+constructorPattern       ::= ID ("(" pattern ("," pattern)* ")")?
+variablePattern          ::= ID
+wildcardPattern          ::= "_"
 ```
 
-**Examples:**
 ```osprey
-// Required for any types
+// Narrowing an any value
 match anyValue {
-    num: Int => num + 1
-    text: String => length(text)
-    flag: Bool => if flag then 1 else 0
+    n: int    => n + 1
+    s: string => length(s)
+    b: bool   => match b {
+        true  => 1
+        false => 0
+    }
     _ => 0
 }
 
-// Structural matching - matches any type with these fields
+// Structural matching: any type with these field names
 match anyValue {
-    { name, age } => print("${name}: ${age}")           // Anonymous structural
-    p: { name, age } => print("Person ${p.name}: ${p.age}")  // Named structural
-    u: User { id } => print("User ${id}")               // Traditional typed
-    _ => print("Unknown")
+    { name, age }       => print("${name}: ${age}")
+    p: { name, age }    => print("person ${p.name}: ${p.age}")   // bind whole + destructure
+    u: User { id }      => print("user ${id}")                   // typed structural
+    _                   => print("unknown")
 }
 
-// Advanced structural patterns
+// Type-narrowed structural fields
 match anyValue {
-    { x, y } => print("Point: (${x}, ${y})")           // Any type with x, y fields
-    p: { name } => print("Named thing: ${p.name}")     // Any type with name field
-    { id, email, active: Bool } => print("Active user: ${id}")  // Mixed field patterns
-    _ => print("No match")
+    { x, y }                       => print("point: (${x}, ${y})")
+    p: { name }                    => print("named: ${p.name}")
+    { id, email, active: bool }    => print("active user: ${id}")
+    _                              => print("no match")
 }
 
-// Type patterns with field destructuring
+// Type pattern with destructuring of a known constructor
 match result {
-    success: Success { value, timestamp } => processSuccess(value, timestamp)
-    error: Error { code, message } => handleError(code, message)
-    _ => defaultHandler()
+    success: Success { value, timestamp } => processSuccess(value: value, timestamp: timestamp)
+    error:   Error   { code, message }    => handleError(code: code, message: message)
+    _                                     => defaultHandler()
 }
 ```
 
-## Pattern Matching Features
+## Result Patterns
 
-#### **1. Type Annotation Patterns**
-```osprey
-match anyValue {
-    i: Int => i * 2                    // Bind as 'i' if Int
-    s: String => s + "!"               // Bind as 's' if String
-    user: User => user.name            // Bind as 'user' if User type
-}
-```
+`Result<T, E>` is matched the same way as any other union. See [Error Handling](0013-ErrorHandling.md) for the type and arithmetic semantics.
 
-#### **2. Anonymous Structural Matching**
-Match on structure without requiring specific type names:
-```osprey
-match anyValue {
-    { name, age } => print("${name} is ${age}")        // ANY type with name, age
-    { x, y, z } => print("3D point: ${x},${y},${z}")   // ANY type with x, y, z
-    { id } => print("Has ID: ${id}")                    // ANY type with id field
-}
-```
-
-#### **3. Named Structural Matching**
-Bind the whole object AND destructure fields:
-```osprey
-match anyValue {
-    person: { name, age } => {
-        print("Person: ${person}")      // Access whole object
-        print("Name: ${name}")          // Access destructured field
-        print("Age: ${age}")            // Access destructured field
-    }
-    point: { x, y } => calculateDistance(point, origin)
-}
-```
-
-#### **4. Mixed Type and Structural Patterns**
-```osprey
-match anyValue {
-    user: User { id, name } => print("User ${id}: ${name}")     // Explicit type
-    { email, active } => print("Has email: ${email}")           // Structural only
-    data: { values: Array<Int> } => processArray(data.values)   // Nested types
-    _ => print("Unknown structure")
-}
-```
-
-## Result Type Pattern Matching (Arithmetic Expressions)
-
-All arithmetic expressions return `Result<T, MathError>` and must be handled with pattern matching. The compiler automatically unwraps intermediate Results in nested arithmetic, so only the final result requires pattern matching.
-
-**✨ KEY INSIGHT**: Nested arithmetic expressions do NOT require nested pattern matching! The compiler automatically unwraps intermediate Results, so you only pattern match the final result.
-
-### Simple Arithmetic Result Handling
 ```osprey
 let calculation = 1 + 3 + (300 / 5)  // Result<int, MathError>
 
 match calculation {
-    Success { value } => print("Result: ${value}")
-    Error { message } => print("Math error: ${message}")
+    Success { value }   => print("Result: ${value}")
+    Error   { message } => print("Math error: ${message}")
 }
 ```
 
-### Compound Arithmetic Expressions
+Compound arithmetic expressions yield a single `Result`, not nested `Result`s; the compiler unwraps intermediate values inside the chain. Only the final value needs to be matched.
 
-Nested arithmetic expressions return a single Result, not nested Results:
+## Ternary Match (Syntactic Sugar)
+
+A two-arm match has a shorthand. Two equivalent forms exist:
+
+```ebnf
+ternary ::= expr "{" pattern "}" "?" expr ":" expr   (* structural form *)
+          | expr "?:" expr                            (* Result default form *)
+```
+
+Structural form — pick out a field, fall back if the pattern fails:
 
 ```osprey
-let simple = 10 + 5                    // Result<int, MathError>
-let complex = 1 + 2 * 3 - 4 / 2        // Result<int, MathError>
-let nested = ((a + b) * c) / (d - e)   // Result<int, MathError>
+let calculation = 10 + 5
+let value = calculation { value } ? value : -1   // 15
+```
 
-// All handled the same way
-match simple {
-    Success { value } => print("Result: ${value}")
-    Error { message } => print("Error: ${message}")
+Desugars to:
+
+```osprey
+match calculation {
+    { value } => value
+    _         => -1
 }
 ```
 
-The compiler auto-unwraps intermediate Results in arithmetic chains:
+Result-default form — extract `Success { value }` or use the default on `Error`:
 
 ```osprey
-let example = (10 + 5) * 2  // Single Result<int, MathError>
-match example {
-    Success { value } => print(value)  // 30
-    Error { message } => print(message)
-}
+let safeValue = divide(a: 10, b: 2) ?: -1   // 5
+let errorVal  = divide(a: 10, b: 0) ?: -1   // -1
 ```
 
-### Result toString Format
-```osprey
-let x = 10 + 5  // Result<int, MathError>
-print(x)        // Prints: Success(15)
-
-let y = 10 / 0  // Result<float, MathError>
-print(y)        // Prints: Error(DivisionByZero)
-
-// Success format: Success(value)
-// Error format: Error(message)
-```
-
-### Function Return Results
-```osprey
-fn calculate(x: int, y: int) -> Result<int, MathError> = x + y * 2 - 5
-
-let result = calculate(10, 3)  // Result<int, MathError>
-match result {
-    Success { value } => print("Function result: ${value}")
-    Error { message } => print("Function failed: ${message}")
-}
-```
-
-### Advanced Result Chains
-```osprey
-// Multiple Results in sequence
-let step1 = 100 + 50        // Result<int, MathError>
-let step2 = 200 * 3         // Result<int, MathError>
-
-// Handle each step
-match step1 {
-    Success { value1 } => {
-        match step2 {
-            Success { value2 } => {
-                let final = value1 + value2  // This is also Result<int, MathError>!
-                match final {
-                    Success { total } => print("Final: ${total}")
-                    Error { message } => print("Final calc failed: ${message}")
-                }
-            }
-            Error { message } => print("Step 2 failed: ${message}")
-        }
-    }
-    Error { message } => print("Step 1 failed: ${message}")
-}
-```
-
-## Match Expression Type Safety Rules
-
-```
-
-## Ternary Match Expression (Syntactic Sugar)
-
-To reduce verbosity for common two-armed match scenarios, Osprey provides a concise ternary match expression. This is **purely syntactic sugar** and desugars to a standard `match` expression internally.
-
-**Syntax:**
-`<expression> { <pattern> } ? <then_expr> : <else_expr>`
-
-This is exactly equivalent to:
-```osprey
-match <expression> {
-    { <pattern> } => <then_expr>
-    _ => <else_expr>
-}
-```
-
-### Breakdown
-
-- **`<expression>`**: The value to be matched.
-- **`{ <pattern> }`**: A structural pattern to match against the expression. This can be used for destructuring.
-- **`? <then_expr>`**: The expression to evaluate if the pattern matches.
-- **`: <else_expr>`**: The expression to evaluate if the pattern does not match.
-
-### Examples
-
-**Example 1: Handling Built-in `Result` Types**
-
-The built-in `Result<T, E>` type uses `Success { value: T }` and `Error { message: E }` constructors.
+A boolean expression with `?:` works because `true`/`false` desugar to the same match:
 
 ```osprey
-// Arithmetic operations return Result<int, MathError>
-let calculation = 10 + 5  // Result<int, MathError>
-
-// Extracts value using the structural ternary match
-let message = calculation { value } ? value : -1
-// message is now 15
-
-// Function returning Result type  
-fn divide(a: int, b: int) -> Result<int, MathError> = a / b
-let result = divide(a: 10, b: 2)
-let safeValue = result { value } ? value : 0
-// safeValue is now 5
-```
-
-**Example 2: Handling Booleans**
-
-The ternary match can also work with boolean values by matching on the implicit structure of a `true` value.
-
-```osprey
-let is_active = true
-let status_text = is_active ? "Active" : "Inactive"
-// status_text is now "Active"
-```
-
-**Example 3: Handling Result Types with Ternary**
-
-For Result types, the ternary operator provides a clean way to extract success values or provide defaults:
-
-```osprey
-// Arithmetic operations return Result<int, MathError>
-let calculation = 10 + 5  // Result<int, MathError>
-
-// Result ternary: automatically extracts Success value or uses default on Error
-let value = calculation ?: -1  // 15 (extracts value from Success) or -1 (on Error)
-
-// Function returning Result type
-fn divide(a: int, b: int) -> Result<int, MathError> = a / b
-
-let goodResult = divide(a: 10, b: 2)
-let safeValue = goodResult ?: -1  // 5 (extracts value from Success) or -1 (on Error)
-
-let badResult = divide(a: 10, b: 0)  
-let errorValue = badResult ?: -1  // -1 (Error case, uses default)
-```
-
-This is syntactic sugar for:
-```osprey
-let value = match calculation {
-    Success { value } => value
-    Error { message } => -1
-}
+let status = isActive ? "Active" : "Inactive"
 ```

--- a/compiler/spec/0008-BlockExpressions.md
+++ b/compiler/spec/0008-BlockExpressions.md
@@ -1,11 +1,6 @@
-9. [Block Expressions](0009-BlockExpressions.md)
-   - [Block Scoping Rules](#block-scoping-rules)
-   - [Block Return Values](#block-return-values)
-   - [Performance Characteristics](#performance-characteristics)
-
 # Block Expressions
 
-Block expressions allow grouping multiple statements together and returning a value from the final expression. They create a new scope for variable declarations and enable sequential execution with proper scoping rules.
+A block expression groups statements and returns the value of its final expression. Each block introduces a new lexical scope.
 
 ```
 block_expression := '{' statement* expression? '}'
@@ -65,15 +60,4 @@ print("Outer x: ${x}")      // 100 (unchanged)
 
 ## Block Return Values
 
-Block expressions return the value of their final expression:
-- If the block ends with an expression, that value is returned
-- If the block has no final expression, it returns the unit type
-- The block's type is determined by the type of the final expression
-
-## Performance Characteristics
-
-Block expressions are zero-cost abstractions:
-- **Compile-time scoping**: All variable scoping resolved at compile time
-- **No runtime overhead**: Blocks compile to sequential instructions
-- **Stack allocation**: Local variables allocated on the stack
-- **Optimized away**: Simple blocks with no local variables are optimized away 
+A block ending with an expression returns that expression's value and adopts its type. A block ending with a statement returns `unit`.

--- a/compiler/spec/0009-BooleanOperations.md
+++ b/compiler/spec/0009-BooleanOperations.md
@@ -1,45 +1,29 @@
-10. [Boolean Operations](0010-BooleanOperations.md)
-    - [Boolean Pattern Matching](#boolean-pattern-matching)
-    - [Boolean Operators](#boolean-operators)
-
 # Boolean Operations
 
-Use pattern matching for conditional logic:
+Osprey has no `if`/`else` statement. Conditional logic is written as a `match` on a boolean (which forces both arms to be considered) or as the ternary shorthand `cond ? then : else`, which desugars to the same `match`. The ternary is defined in [Pattern Matching](0007-PatternMatching.md#ternary-match-syntactic-sugar).
 
-**Examples:**
 ```osprey
-let result = match x > 0 {
-    true => "positive"
-    false => "zero or negative"
+let status = match isValid {
+    true  => "Success"
+    false => "Failure"
 }
 
 let max = match a > b {
-    true => a
+    true  => a
     false => b
 }
 ```
 
-## Boolean Pattern Matching
+Nested matches handle compound conditions:
 
-Osprey uses pattern matching instead of traditional if-else statements for boolean operations. This ensures exhaustive handling of both true and false cases.
-
-**Basic Boolean Matching:**
-```osprey
-let status = match isValid {
-    true => "Success"
-    false => "Failure"
-}
-```
-
-**Complex Boolean Logic:**
 ```osprey
 let category = match score >= 90 {
-    true => match score == 100 {
-        true => "Perfect"
+    true  => match score == 100 {
+        true  => "Perfect"
         false => "Excellent"
     }
     false => match score >= 70 {
-        true => "Good"
+        true  => "Good"
         false => "Needs Improvement"
     }
 }
@@ -47,28 +31,12 @@ let category = match score >= 90 {
 
 ## Boolean Operators
 
-- `&&` - Logical AND
-- `||` - Logical OR  
-- `!` - Logical NOT
-- `==` - Equality
-- `!=` - Inequality
-- `>`, `<`, `>=`, `<=` - Comparison operators
+`&&`, `||`, and `!` are short-circuiting; `==`, `!=`, `<`, `>`, `<=`, `>=` produce booleans. See [Lexical Structure](0002-LexicalStructure.md) for the full operator list.
 
-**Operator Examples:**
 ```osprey
-let isAdult = age >= 18
+let isAdult       = age >= 18
 let hasPermission = isAdult && isAuthorized
-let canAccess = hasPermission || isAdmin
-let isBlocked = !isActive
-
-// Complex logical expressions with parentheses
-let complexLogic = (score >= 90) && (attendance > 0.8)
-let shouldNotify = (status == "urgent") || (priority > 5)
-let validUser = !isBanned && (isVerified || hasInvite)
+let canAccess     = hasPermission || isAdmin
+let isBlocked     = !isActive
+let validUser     = !isBanned && (isVerified || hasInvite)
 ```
-
-**Short-Circuit Evaluation:**
-
-Logical operators use short-circuit evaluation for performance:
-- `&&` (AND): If left operand is false, right operand is not evaluated
-- `||` (OR): If left operand is true, right operand is not evaluated

--- a/compiler/spec/0010-LoopConstructsAndFunctionalIterators.md
+++ b/compiler/spec/0010-LoopConstructsAndFunctionalIterators.md
@@ -1,180 +1,88 @@
-11. [Loop Constructs and Functional Iterators](0011-LoopConstructsAndFunctionalIterators.md)
-    - [Functional Iteration Philosophy](#functional-iteration-philosophy)
-    - [Core Iterator Functions](#core-iterator-functions)
-        - [`range(start: int, end: int) -> Iterator<int>`](#rangestart-int-end-int---iteratorint)
-        - [`forEach(iterator: Iterator<T>, function: T -> U) -> T`](#foreachiterator-iteratort-function-t---u---t)
-        - [`map(iterator: Iterator<T>, function: T -> U) -> U`](#mapiterator-iteratort-function-t---u---u)
-        - [`filter(iterator: Iterator<T>, predicate: T -> bool) -> T`](#filteriterator-iteratort-predicate-t---bool---t)
-        - [`fold(iterator: Iterator<T>, initial: U, function: (U, T) -> U) -> U`](#folditerator-iteratort-initial-u-function-u-t---u---u)
-    - [Pipe Operator](#pipe-operator)
-        - [`|>` - Pipe Operator](#---pipe-operator)
-    - [Stream Fusion Optimization](#stream-fusion-optimization)
-        - [How Stream Fusion Works](#how-stream-fusion-works)
-        - [Performance Benefits](#performance-benefits)
-        - [Supported Fusion Chains](#supported-fusion-chains)
-    - [Functional Programming Patterns](#functional-programming-patterns)
-        - [Chaining Pattern](#chaining-pattern)
-        - [Side Effect Pattern](#side-effect-pattern)
-        - [Data Transformation Pattern](#data-transformation-pattern)
-    - [Why No Imperative Loops?](#why-no-imperative-loops)
+# Iterators and Iteration
 
-# Loop Constructs and Functional Iterators
-
-Osprey is a functional language without imperative loop constructs. Iteration uses functional patterns with the core functions `range`, `forEach`, `map`, `filter`, and `fold`, composed with the pipe operator `|>`.
-
-## Functional Iteration
-
-Functional iteration provides composable, safe patterns without mutable state. Fibers handle concurrent iteration, and pure functions simplify testing.
+Osprey has no `for`, `while`, or `loop` construct. Iteration is expressed as composition of `range`, `forEach`, `map`, `filter`, and `fold` using the pipe operator `|>`.
 
 ## Core Iterator Functions
 
+All multi-argument iterator functions are intended to be used through the pipe; their full signatures are listed for reference. Direct calls require named arguments per [Function Calls](0005-FunctionCalls.md).
+
 ### `range(start: int, end: int) -> Iterator<int>`
-Creates an iterator that generates integers from start (inclusive) to end (exclusive).
+Generates integers from `start` (inclusive) to `end` (exclusive).
 
 ```osprey
-range(1, 5)    // generates 1, 2, 3, 4
-range(0, 3)    // generates 0, 1, 2
-range(10, 13)  // generates 10, 11, 12
+range(start: 1,  end: 5)    // 1, 2, 3, 4
+range(start: 0,  end: 3)    // 0, 1, 2
+range(start: 10, end: 13)   // 10, 11, 12
 ```
 
-### `forEach(iterator: Iterator<T>, function: T -> U) -> T`
-Applies a function to each element in an iterator for side effects.
+### `forEach(iterator: Iterator<T>, function: fn(T) -> U) -> unit`
+Applies `function` to each element for its side effects.
 
 ```osprey
-range(1, 5) |> forEach(print)          // prints 1, 2, 3, 4
-forEach(range(0, 3), double)           // calls double(0), double(1), double(2)
+range(start: 1, end: 5) |> forEach(print)
 ```
 
-### `map(iterator: Iterator<T>, function: T -> U) -> U`
-Transforms each element in an iterator by applying a function.
+### `map(iterator: Iterator<T>, function: fn(T) -> U) -> Iterator<U>`
+Transforms each element.
 
 ```osprey
-range(1, 5) |> map(double)    // applies double to 1, 2, 3, 4
-map(range(0, 3), square)      // applies square to 0, 1, 2
+range(start: 1, end: 5) |> map(double)
 ```
 
-### `filter(iterator: Iterator<T>, predicate: T -> bool) -> T`
-Selects elements from an iterator based on a predicate function.
+### `filter(iterator: Iterator<T>, predicate: fn(T) -> bool) -> Iterator<T>`
+Keeps elements that satisfy `predicate`.
 
 ```osprey
-range(1, 10) |> filter(isEven)
-filter(range(0, 20), isPositive)
+range(start: 1, end: 10) |> filter(isEven)
 ```
 
-### `fold(iterator: Iterator<T>, initial: U, function: (U, T) -> U) -> U`
-Reduces an iterator to a single value by repeatedly applying a function.
+### `fold(iterator: Iterator<T>, initial: U, function: fn(U, T) -> U) -> U`
+Reduces an iterator to a single value.
 
 ```osprey
-range(1, 5) |> fold(0, add)          // sum: 0+1+2+3+4 = 10
-fold(range(1, 6), 1, multiply)       // product: 1*1*2*3*4*5 = 120
+range(start: 1, end: 5) |> fold(initial: 0, function: add)   // 0+1+2+3+4 = 10
 ```
 
 ## Pipe Operator
 
-### `|>` - Pipe Operator
-The pipe operator creates clean, readable function composition by allowing you to chain operations from left to right.
+`|>` passes its left operand as the first argument to the function on its right.
 
 ```osprey
-// Basic piping
-5 |> double |> print                 // Equivalent to: print(double(5))
-
-// Iterator chaining
-range(1, 10) |> forEach(print)
-range(1, 5) |> map(square) |> fold(0, add)
-
-// Complex chains
-range(0, 20) |> filter(isEven) |> map(double) |> forEach(print)
+5 |> double |> print                                                 // print(double(5))
+range(start: 1, end: 10) |> forEach(print)
+range(start: 0, end: 20) |> filter(isEven) |> map(double) |> forEach(print)
 ```
 
-## Stream Fusion Optimization
+## Stream Fusion
 
-Osprey implements **stream fusion** - a compile-time optimization that eliminates intermediate data structures when chaining iterator operations. This provides zero-cost abstractions: you write elegant functional code that compiles to the same performance as hand-optimized loops.
+Chains of `map`, `filter`, `forEach`, and `fold` over an iterator are fused at compile time into a single loop with no intermediate collections. The chain
 
-### How Stream Fusion Works
-
-When you write:
 ```osprey
-range(1, 5) |> map(double) |> filter(isEven) |> forEach(print)
+range(start: 1, end: 5) |> map(double) |> filter(isEven) |> forEach(print)
 ```
 
-**Without stream fusion** (naive approach):
-1. `range(1, 5)` creates array `[1, 2, 3, 4]`
-2. `map(double)` creates new array `[2, 4, 6, 8]`
-3. `filter(isEven)` creates new array `[2, 4, 6, 8]`
-4. `forEach(print)` iterates and prints
+compiles to one loop that applies `double`, the `isEven` test, and `print` per element — equivalent to:
 
-**With stream fusion** (Osprey's approach):
-- Compiler detects the chain at compile time
-- `map()` stores the transformation function, returns range unchanged
-- `filter()` stores the predicate function, returns range unchanged
-- `forEach()` generates a single optimized loop that applies all transformations inline
-
-The generated LLVM IR is equivalent to:
 ```c
-// Hand-optimized loop - what Osprey generates
 for (i = 1; i < 5; i++) {
-    value = double(i);           // map applied inline
-    if (isEven(value)) {         // filter applied inline
-        print(value);            // forEach applied inline
-    }
+    value = double(i);
+    if (isEven(value)) print(value);
 }
 ```
 
-### Performance Benefits
+Fusion applies to any chain of `map` and `filter` terminated by `forEach` or `fold`.
 
-**Zero-cost abstractions:**
-- ✅ No intermediate arrays or memory allocations
-- ✅ Single pass through data instead of multiple iterations
-- ✅ Better CPU cache utilization
-- ✅ Same performance as hand-written optimized loops
+## Patterns
 
-**Example:**
 ```osprey
-// Elegant functional code
-range(1, 1000000)
+// Transform → filter → aggregate
+range(start: 1, end: 20)
   |> map(square)
   |> filter(isEven)
-  |> fold(0, add)
+  |> fold(initial: 0, function: add)
+  |> print
 
-// Compiles to single optimized loop with:
-// - Zero memory allocations
-// - Zero intermediate arrays
-// - Optimal CPU cache usage
-```
-
-### Supported Fusion Chains
-
-Stream fusion works with any combination of:
-- `map()` - Transforms are fused inline
-- `filter()` - Predicates are fused as conditional branches
-- `forEach()` - Terminal operation that consumes the fused chain
-- `fold()` - Terminal operation that consumes and reduces
-
-Multiple transformations and filters can be chained together and will all be fused into a single optimized loop.
-
-## Functional Programming Patterns
-
-### Chaining Pattern
-```osprey
-// Transform -> Filter -> Aggregate
-range(1, 20)
-  |> map(square)           // Square each number
-  |> filter(isEven)        // Keep only even results
-  |> fold(0, add)          // Sum them up
-  |> print                 // Print the result
-```
-
-### Side Effect Pattern
-```osprey
-// Process each element for side effects
-range(1, 100)
-  |> filter(isPrime)
-  |> forEach(print)        // Print each prime
-```
-
-### Data Transformation Pattern
-```osprey
-// Transform data through multiple stages
+// Pipeline of named stages
 input()
   |> validateInput
   |> normalizeData
@@ -182,16 +90,3 @@ input()
   |> formatOutput
   |> print
 ```
-
-## Alternative to Imperative Loops
-
-Use functional patterns instead of imperative loops:
-
-```osprey
-// Functional approach
-fn serverHandler() -> unit = {
-    requestStream()
-    |> map(processRequest)
-    |> forEach(sendResponse)
-}
-``` 

--- a/compiler/spec/0011-LightweightFibersAndConcurrency.md
+++ b/compiler/spec/0011-LightweightFibersAndConcurrency.md
@@ -1,424 +1,119 @@
-12. [Lightweight Fibers and Concurrency](0012-LightweightFibersAndConcurrency.md)
-    - [Fiber Types and Concurrency](#fiber-types-and-concurrency)
-        - [Core Fiber Types](#core-fiber-types)
-        - [Fiber Construction](#fiber-construction)
-        - [Spawn Syntax Sugar](#spawn-syntax-sugar)
-        - [Channel Construction](#channel-construction)
-        - [Fiber Operations](#fiber-operations)
-        - [Complete Fiber Example](#complete-fiber-example)
-        - [Select Expression for Channel Multiplexing](#select-expression-for-channel-multiplexing)
-        - [Rust Interoperability](#rust-interoperability)
-    - [Fiber-Isolated Module System](#fiber-isolated-module-system)
-        - [Module Isolation Principles](#module-isolation-principles)
-        - [Module Declaration Syntax](#module-declaration-syntax)
-        - [Fiber Isolation Behavior](#fiber-isolation-behavior)
-        - [Memory and Performance Characteristics](#memory-and-performance-characteristics)
-        - [Inter-Fiber Communication](#inter-fiber-communication)
-    - [Server Applications and Long-Running Processes](#server-applications-and-long-running-processes)
-        - [Functional Approaches to Server Persistence](#functional-approaches-to-server-persistence)
-            - [Fiber-Based Server Persistence](#fiber-based-server-persistence)
-            - [Recursive Function Patterns](#recursive-function-patterns)
-            - [Event-Driven Architecture with Channels](#event-driven-architecture-with-channels)
-            - [Functional Iterator-Based Processing](#functional-iterator-based-processing)
-        - [Why No Imperative Loops?](#why-no-imperative-loops)
-        - [Performance Considerations](#performance-considerations)
+# Fibers and Concurrency
 
-## Lightweight Fibers and Concurrency
+Fibers are lightweight concurrent computations. They are constructed as values of `Fiber<T>` and communicate through `Channel<T>`. There are no OS threads exposed to user code; the runtime schedules fibers cooperatively.
 
-🚧 **IMPLEMENTATION STATUS**: Fiber syntax is partially implemented. Basic fiber operations (`spawn`, `await`, `yield`) are in the grammar but runtime support is limited.
+## Status
 
-❌ **NOT IMPLEMENTED**: The fiber-isolated module system is a design goal but not yet implemented. Current module support is basic.
+`spawn`, `await`, `yield`, and basic channel operations are implemented. The `select` expression and the fiber-isolated module system below are planned and not yet wired through code generation.
 
-### Fiber Types and Concurrency
-
-Osprey provides lightweight concurrency through fiber types. Unlike traditional function-based approaches, fibers are proper type instances constructed using Osprey's standard type construction syntax.
-
-#### Core Fiber Types
-
-**`Fiber<T>`** - A lightweight concurrent computation that produces a value of type T
-**`Channel<T>`** - A communication channel for passing values of type T between fibers
-
-#### Fiber Construction
-
-Fibers are created using standard type construction syntax:
+## Core Types
 
 ```osprey
-// Create a fiber that computes a value
-let task = Fiber<Int> { 
-    computation: fn() => calculatePrimes(n: 1000) 
-}
+Fiber<T>     // a concurrent computation that produces a value of type T
+Channel<T>   // an in-process communication channel carrying values of type T
+```
 
-// Create a fiber with more complex computation
-let worker = Fiber<String> { 
-    computation: fn() => {
-        processData()
-        "completed"
-    }
-}
+## Constructing Fibers
 
-// Create a parameterized fiber
-let calculator = Fiber<Int> { 
-    computation: fn() => multiply(x: 10, y: 20) 
+Fibers are constructed using ordinary record-construction syntax:
+
+```osprey
+let task = Fiber<int> {
+    computation: fn() => calculatePrimes(n: 1000)
 }
 ```
 
-#### Spawn Syntax Sugar
-
-For convenience, Osprey provides `spawn` as syntax sugar for creating and immediately starting a fiber:
+`spawn <expr>` is sugar for the equivalent `Fiber` construction:
 
 ```osprey
-// Using spawn (syntax sugar)
 let result = spawn 42
-
-// Equivalent to:
-let fiber = Fiber<Int> { computation: fn() => 42 }
-let result = fiber
-
-// More complex spawn
-let computation = spawn (x * 2 + y)
-
-// Equivalent to:
-let fiber = Fiber<Int> { computation: fn() => x * 2 + y }
-let computation = fiber
+// equivalent to:
+let result = Fiber<int> { computation: fn() => 42 }
 ```
 
-The `spawn` keyword immediately evaluates the expression in a new fiber context, making it convenient for quick concurrent computations without the full type construction syntax.
-
-#### Channel Construction
-
-Channels are created using type construction syntax:
+## Constructing Channels
 
 ```osprey
-// Unbuffered (synchronous) channel
-let sync_channel = Channel<Int> { capacity: 0 }
-
-// Buffered (asynchronous) channel  
-let async_channel = Channel<String> { capacity: 10 }
-
-// Large buffer channel
-let buffer_channel = Channel<Int> { capacity: 100 }
+let sync   = Channel<int>    { capacity: 0  }   // unbuffered (rendezvous)
+let buf    = Channel<string> { capacity: 10 }   // buffered
 ```
 
-#### Fiber Operations
+## Operations
 
-Once created, fibers and channels are manipulated using functional operations:
+| Operation                                       | Signature                                            |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| Wait for a fiber to produce its value           | `await(fiber: Fiber<T>) -> T`                        |
+| Send a value to a channel                       | `send(channel: Channel<T>, value: T) -> Result<unit, ChannelError>` |
+| Receive a value from a channel                  | `recv(channel: Channel<T>) -> Result<T, ChannelError>` |
+| Yield to the scheduler                          | `yield() -> unit`                                    |
 
-**`await(fiber: Fiber<T>) -> T`** - Wait for fiber completion and get result
-**`send(channel: Channel<T>, value: T) -> Result<Unit, ChannelError>`** - Send value to channel
-**`recv(channel: Channel<T>) -> Result<T, ChannelError>`** - Receive value from channel
-**`yield() -> Unit`** - Voluntarily yield control to scheduler
-
-```osprey
-// Create and await a fiber
-let task = Fiber<Int> { computation: fn() => heavyComputation() }
-let result = await(task)
-
-// Channel communication
-let ch = Channel<String> { capacity: 5 }
-send(ch, "hello")
-let message = recv(ch)
-
-// Yielding control
-yield()
-```
-
-#### Complete Fiber Example
+## Producer / Consumer Example
 
 ```osprey
-// Producer fiber
-let producer = Fiber<Unit> {
-    computation: fn() => {
-        let ch = Channel<Int> { capacity: 3 }
-        send(ch, 1)
-        send(ch, 2) 
-        send(ch, 3)
+let ch = Channel<int> { capacity: 3 }
+
+let producer = spawn {
+    send(channel: ch, value: 1)
+    send(channel: ch, value: 2)
+    send(channel: ch, value: 3)
+}
+
+let consumer = spawn {
+    match recv(ch) {
+        Success { value } => print("got ${value}")
+        Error   { message } => print("recv error: ${message}")
+    }
+    match recv(ch) {
+        Success { value } => print("got ${value}")
+        Error   { message } => print("recv error: ${message}")
+    }
+    match recv(ch) {
+        Success { value } => print("got ${value}")
+        Error   { message } => print("recv error: ${message}")
     }
 }
 
-// Consumer fiber
-let consumer = Fiber<Unit> {
-    computation: fn() => {
-        let ch = Channel<Int> { capacity: 3 }
-        let value1 = recv(ch)
-        let value2 = recv(ch)
-        let value3 = recv(ch)
-        print("Received: ${value1}, ${value2}, ${value3}")
-    }
-}
-
-// Start both fibers
 await(producer)
 await(consumer)
 ```
 
-#### Select Expression for Channel Multiplexing
+## select (planned)
 
-The `select` expression allows waiting on multiple channel operations:
+`select` waits on multiple channel operations and runs the arm whose operation completes first:
+
+```ebnf
+selectExpr ::= "select" "{" selectArm+ "}"
+selectArm  ::= IDENT "=>" channelOp "=>" expr
+             | "_"   "=>" expr   (* timeout / default *)
+```
 
 ```osprey
-let ch1 = Channel<String> { capacity: 1 }
-let ch2 = Channel<Int> { capacity: 1 }
+let ch1 = Channel<string> { capacity: 1 }
+let ch2 = Channel<int>    { capacity: 1 }
 
-let result = select {
-    msg => recv(ch1) => process_string(msg)
-    num => recv(ch2) => process_number(num)
-    _ => timeout_handler()
+select {
+    msg => recv(ch1) => processString(msg)
+    num => recv(ch2) => processNumber(num)
+    _   => timeoutHandler()
 }
 ```
 
-#### Rust Interoperability
+## Fiber-Isolated Modules (planned)
 
-Osprey fibers are designed to interoperate with Rust's async/await system:
-
-```osprey
-// Osprey fiber that calls Rust async function
-extern fn rust_async_task() -> Future<Int>
-
-let osprey_task = Fiber<Int> {
-    computation: fn() => await(rust_async_task())
-}
-
-let result = await(osprey_task)
-```
-
-## Fiber-Isolated Module System
-
-❌ **NOT IMPLEMENTED**: The fiber-isolated module system is a design goal but not yet implemented. Current module support is basic.
-
-### Module Isolation Principles
-
-The fiber-isolated module system eliminates data races by design through:
-
-1. **Fiber-Local State**: Each fiber gets its own isolated copy of module state
-2. **No Shared Mutable State**: Modules cannot share mutable data between fibers
-3. **Immutable Sharing**: Only immutable data can be shared between fibers
-4. **Automatic Isolation**: Module isolation happens automatically without explicit synchronization
-
-### Module Declaration Syntax
-
-```osprey
-module ModuleName {
-    // Module declarations
-    let value = 42
-    mut counter = 0
-    
-    fn increment() -> Int = {
-        counter = counter + 1
-        counter
-    }
-    
-    fn getValue() -> Int = value
-}
-```
-
-### Fiber Isolation Behavior
-
-When a fiber accesses a module, it gets its own isolated instance:
+Each fiber that touches a `module` receives its own private instance. There is no shared mutable state across fibers; communication is via channels.
 
 ```osprey
 module Counter {
     mut count = 0
-    
-    fn increment() -> Int = {
-        count = count + 1
-        count
-    }
-    
-    fn get() -> Int = count
+    fn increment() -> int = { count = count + 1; count }
+    fn get()       -> int = count
 }
 
-// Each fiber gets its own Counter instance
-let fiber1 = spawn Counter.increment()  // Returns 1
-let fiber2 = spawn Counter.increment()  // Also returns 1 (separate instance)
+let f1 = spawn Counter.increment()   // 1
+let f2 = spawn Counter.increment()   // 1, not 2 — separate instance
 
-let result1 = await(fiber1)  // 1
-let result2 = await(fiber2)  // 1 (not 2!)
+await(f1)
+await(f2)
 ```
 
-### Memory and Performance Characteristics
-
-- **Copy-on-First-Access**: Module instances are copied when first accessed by a fiber
-- **Memory Isolation**: Each fiber's module state is completely isolated
-- **No Synchronization Overhead**: No locks, atomics, or other synchronization primitives needed
-- **Deterministic Behavior**: Same input always produces same output within a fiber
-
-### Inter-Fiber Communication
-
-Since modules are isolated, inter-fiber communication must use explicit channels:
-
-```osprey
-module Database {
-    mut connections = []
-    
-    fn connect() -> Connection = {
-        // This connection is fiber-local
-        let conn = createConnection()
-        connections = conn :: connections
-        conn
-    }
-}
-
-// Fibers communicate via channels, not shared module state
-let resultChannel = Channel<String> { capacity: 10 }
-
-let worker1 = spawn {
-    let conn = Database.connect()  // Fiber-local connection
-    let result = query(conn, "SELECT * FROM users")
-    send(resultChannel, result)
-}
-
-let worker2 = spawn {
-    let conn = Database.connect()  // Different fiber-local connection  
-    let result = query(conn, "SELECT * FROM products")
-    send(resultChannel, result)
-}
-```
-
-This design ensures that concurrent access to modules is always safe without requiring explicit synchronization.
-
-## Server Applications and Long-Running Processes
-
-### Functional Approaches to Server Persistence
-
-**Osprey is a functional language and does NOT support imperative loop constructs.** Server applications that need to stay alive should use functional patterns instead:
-
-#### Fiber-Based Server Persistence
-
-Use fibers to handle concurrent requests and keep the server process alive:
-
-```osprey
-// HTTP server with fiber-based request handling
-fn handleRequest(requestId: Int) -> Int = {
-    // Process the request
-    let response = processData(requestId)
-    response
-}
-
-fn serverMain() -> Unit = {
-    let server = httpCreateServer(port: 8080, address: "0.0.0.0")
-    
-    // Spawn fibers to handle requests concurrently
-    let requestHandler = spawn {
-        // Use functional iteration to process incoming requests
-        range(1, 1000000) |> forEach(handleRequest)
-    }
-    
-    // Keep server alive by awaiting the handler fiber
-    await(requestHandler)
-}
-```
-
-#### Recursive Function Patterns
-
-Use tail-recursive functions for continuous processing:
-
-```osprey
-fn serverLoop(state: ServerState) -> Unit = match getNextRequest(state) {
-    Some { request } => {
-        let newState = processRequest(request, state)
-        serverLoop(newState)  // Tail recursion keeps server alive
-    }
-    None => serverLoop(state)  // Continue waiting for requests
-}
-
-fn main() -> Unit = {
-    let initialState = initializeServer()
-    serverLoop(initialState)  // Functional "loop" via recursion
-}
-```
-
-#### Event-Driven Architecture with Channels
-
-Use channels for event-driven server architectures:
-
-```osprey
-fn eventProcessor(eventChannel: Channel<Event>) -> Unit = {
-    let event = recv(eventChannel)
-    match event {
-        Success { value } => {
-            processEvent(value)
-            eventProcessor(eventChannel)  // Continue processing
-        }
-        Error { _ } => eventProcessor(eventChannel)  // Retry on error
-    }
-}
-
-fn serverWithEvents() -> Unit = {
-    let eventChan = Channel<Event> { capacity: 100 }
-    
-    // Spawn event processor fiber
-    let processor = spawn eventProcessor(eventChan)
-    
-    // Spawn request handlers that send events
-    let handler1 = spawn handleHTTPRequests(eventChan)
-    let handler2 = spawn handleWebSocketRequests(eventChan)
-    
-    // Wait for all handlers
-    await(processor)
-    await(handler1)
-    await(handler2)
-}
-```
-
-#### Functional Iterator-Based Processing
-
-Use functional iterators for continuous data processing:
-
-```osprey
-// Stream processing with functional iterators
-fn processIncomingData() -> Unit = {
-    // Process data in batches using functional approach
-    range(1, Int.MAX_VALUE) 
-    |> map(getBatch)
-    |> filter(isValidBatch)
-    |> forEach(processBatch)
-}
-
-fn webSocketServer() -> Unit = {
-    let server = websocketCreateServer(port: 8080, address: "0.0.0.0", path: "/ws")
-    
-    // Use functional processing instead of loops
-    let dataProcessor = spawn processIncomingData()
-    let connectionHandler = spawn manageConnections(server)
-    
-    await(dataProcessor)
-    await(connectionHandler)
-}
-```
-
-### Why No Imperative Loops?
-
-**Functional Superiority:**
-1. **Composability** - Functional iterators can be chained with `|>`
-2. **Safety** - No mutable state, no infinite loop bugs
-3. **Concurrency** - Fibers provide better parallelism than loops
-4. **Testability** - Pure functions are easier to test than stateful loops
-
-**Anti-Pattern:**
-```osprey
-// ❌ WRONG - Imperative loops (NOT SUPPORTED)
-loop {
-    let request = getRequest()
-    processRequest(request)
-}
-```
-
-**Functional Pattern:**
-```osprey
-// ✅ CORRECT - Functional approach
-fn serverHandler() -> Unit = {
-    requestStream() 
-    |> map(processRequest)
-    |> forEach(sendResponse)
-}
-```
-
-### Performance Considerations
-
-Functional approaches in Osprey are optimized for:
-- **Tail call optimization** prevents stack overflow in recursive functions
-- **Fiber scheduling** provides efficient concurrency without OS threads
-- **Channel buffering** enables high-throughput event processing
-- **Iterator fusion** optimizes chained functional operations
-
-This functional approach provides better maintainability, testability, and performance than traditional imperative loops. 
+A fiber's module instance is initialised on first access (copy-on-first-access) and is destroyed with the fiber.

--- a/compiler/spec/0012-Built-InFunctions.md
+++ b/compiler/spec/0012-Built-InFunctions.md
@@ -1,17 +1,6 @@
-13. [Built-in Functions](0013-Built-InFunctions.md)
-    - [Basic I/O Functions](#basic-io-functions)
-    - [File System Functions](#file-system-functions)
-    - [Process Operations](#process-operations)
-    - [Functional Programming](#functional-programming)
-    - [HTTP Functions](#http-functions)
-    - [WebSocket Functions](#websocket-functions)
-    - [Fiber and Concurrency Functions](#fiber-and-concurrency-functions)
-
 # Built-in Functions
 
-🚀 **IMPLEMENTATION STATUS**: HTTP and basic I/O functions are implemented and working. WebSocket functions are implemented but undergoing testing. Fiber operations are partially implemented.
-
-Osprey provides built-in functions for I/O, networking, concurrency, and functional programming. All functions follow Osprey's functional programming paradigms with Result types for error handling.
+Reference for built-in functions available in every Osprey program. Operations that can fail return `Result`; see [Error Handling](0013-ErrorHandling.md).
 
 ## Basic I/O Functions
 
@@ -52,14 +41,14 @@ match length("hello") {
 Checks if a string contains a substring.
 
 ```osprey
-match contains("hello", "ell") {
-    Success { value } => print("Found: ${value}")
-    Error { message } => print("Error: ${message}")
+match contains(haystack: "hello", needle: "ell") {
+    Success { value }   => print("Found: ${value}")
+    Error   { message } => print("Error: ${message}")
 }
 ```
 
 #### `substring(s: string, start: int, end: int) -> Result<string, StringError>`
-Extracts a substring from start to end.
+Extracts a substring from `start` (inclusive) to `end` (exclusive).
 
 ## File System Functions
 
@@ -80,185 +69,38 @@ Checks if file exists.
 
 ## Process Operations
 
-### `spawnProcess(command: string, callback: fn(int, int, string) -> Unit) -> Result<ProcessResult, string>`
-Spawns external process with asynchronous stdout/stderr collection via callbacks.
+### `spawnProcess(command: string, callback: fn(int, int, string) -> unit) -> Result<ProcessResult, string>`
+Spawns an external process. The callback is invoked for each stdout/stderr line and on exit.
 
 ```osprey
-fn processEventHandler(processID: int, eventType: int, data: string) -> Unit = {
-    match eventType {
-        1 => print("[STDOUT] ${data}")
-        2 => print("[STDERR] ${data}")
-        3 => print("[EXIT] Code: ${data}")
-        _ => print("[UNKNOWN] ${data}")
-    }
+fn processEventHandler(processID: int, eventType: int, data: string) -> unit = match eventType {
+    1 => print("[STDOUT] ${data}")
+    2 => print("[STDERR] ${data}")
+    3 => print("[EXIT] Code: ${data}")
+    _ => print("[UNKNOWN] ${data}")
 }
 
-let result = spawnProcess("echo 'Hello'", processEventHandler)
+let result = spawnProcess(command: "echo 'Hello'", callback: processEventHandler)
 ```
 
 ### `awaitProcess(processId: int) -> int`
-Waits for process completion and returns exit code.
+Waits for process completion and returns the exit code.
 
-### `cleanupProcess(processId: int) -> void`
-Cleans up process resources after completion.
+### `cleanupProcess(processId: int) -> unit`
+Releases process resources.
 
-## Functional Programming
+## Iterators and Pipe
 
-### Iterator Functions
+`range`, `forEach`, `map`, `filter`, `fold`, and `|>` are documented in [Iterators and Iteration](0010-LoopConstructsAndFunctionalIterators.md).
 
-#### `range(start: int, end: int) -> Iterator<int>`
-Creates an iterator from start (inclusive) to end (exclusive).
+## HTTP
 
-```osprey
-range(1, 5)    // generates 1, 2, 3, 4
-```
+See [HTTP](0014-HTTP.md).
 
-#### `forEach(iterator: Iterator<T>, function: T -> U) -> T`
-Applies a function to each element for side effects.
+## WebSockets
 
-```osprey
-range(1, 5) |> forEach(print)          // prints 1, 2, 3, 4
-```
+See [WebSockets](0015-WebSockets.md).
 
-#### `map(iterator: Iterator<T>, function: T -> U) -> U`
-Transforms each element by applying a function.
+## Fibers and Channels
 
-```osprey
-range(1, 5) |> map(double)    // applies double to 1, 2, 3, 4
-```
-
-#### `filter(iterator: Iterator<T>, predicate: T -> bool) -> T`
-Selects elements based on a predicate function.
-
-```osprey
-range(1, 10) |> filter(isEven)
-```
-
-#### `fold(iterator: Iterator<T>, initial: U, function: (U, T) -> U) -> U`
-Reduces an iterator to a single value.
-
-```osprey
-range(1, 5) |> fold(0, add)          // sum: 0+1+2+3+4 = 10
-```
-
-### Pipe Operator `|>`
-
-The pipe operator passes the left expression as the first argument to the right function.
-
-```osprey
-5 |> double |> print                 // Equivalent to: print(double(5))
-range(1, 10) |> map(square) |> filter(isEven) |> forEach(print)
-```
-
-## HTTP Functions
-
-HTTP functions for server and client operations are documented in [Chapter 15 - HTTP](0015-HTTP.md).
-
-## WebSocket Functions
-
-WebSocket functions for real-time bidirectional communication are documented in [Chapter 16 - WebSockets](0016-WebSockets.md).
-
-## Fiber and Concurrency Functions
-
-Osprey provides lightweight concurrency through fibers.
-
-### Fiber Types
-
-```osprey
-// Create a fiber
-let task = Fiber<Int> { 
-    computation: fn() => calculatePrimes(1000) 
-}
-
-// Spawn syntax sugar
-let result = spawn 42
-
-// Channels for communication
-let ch = Channel<String> { capacity: 10 }
-```
-
-### Fiber Operations
-
-#### `await(fiber: Fiber<T>) -> T`
-Wait for fiber completion and get result.
-
-#### `send(channel: Channel<T>, value: T) -> Result<Unit, ChannelError>`
-Send value to channel.
-
-#### `recv(channel: Channel<T>) -> Result<T, ChannelError>`
-Receive value from channel.
-
-#### `yield() -> Unit`
-Voluntarily yield control to scheduler.
-
-### Example Usage
-
-```osprey
-// Producer-consumer pattern
-let ch = Channel<Int> { capacity: 3 }
-
-let producer = spawn {
-    send(ch, 1)
-    send(ch, 2)
-    send(ch, 3)
-}
-
-let consumer = spawn {
-    let value1 = recv(ch)
-    let value2 = recv(ch)
-    let value3 = recv(ch)
-    print("Received values")
-}
-
-await(producer)
-await(consumer)
-```
-
-## Functional Programming Examples
-
-Combining functional programming capabilities for data processing:
-
-```osprey
-fn main() -> Int = {
-    // Calculate sum of squares of even numbers from 1 to 10
-    let evenSquareSum = range(1, 11)
-        |> filter(isEven)
-        |> map(square)
-        |> fold(0, add)
-    
-    print("Sum of squares of even numbers: ${toString(evenSquareSum)}")
-    
-    // Process user data with functional pipeline
-    print("Processing user data:")
-    range(1, 6)
-        |> map(createUserData)
-        |> forEach(print)
-    
-    // Concurrent processing with fibers
-    let ch = Channel<String> { capacity: 3 }
-    
-    let producer = spawn {
-        range(1, 4) |> forEach(fn(i) => send(ch, "Message ${toString(i)}"))
-    }
-    
-    let consumer = spawn {
-        range(1, 4) |> forEach(fn(_) => {
-            match recv(ch) {
-                Success { value } => print("Received: ${value}")
-                Error { message } => print("Error: ${message}")
-            }
-        })
-    }
-    
-    await(producer)
-    await(consumer)
-    
-    0
-}
-
-fn isEven(x: Int) -> Bool = x % 2 == 0
-fn square(x: Int) -> Int = x * x
-fn add(a: Int, b: Int) -> Int = a + b
-
-fn createUserData(id: Int) -> String = 
-    "{\"id\": ${toString(id)}, \"name\": \"User${toString(id)}\"}"
+`spawn`, `await`, `send`, `recv`, `yield`, `Fiber<T>`, `Channel<T>` are documented in [Fibers and Concurrency](0011-LightweightFibersAndConcurrency.md).

--- a/compiler/spec/0013-ErrorHandling.md
+++ b/compiler/spec/0013-ErrorHandling.md
@@ -1,112 +1,63 @@
-14. [Error Handling](0015-ErrorHandling.md)
-    - [The Result Type](#the-result-type)
+# Error Handling
 
-## Error Handling
-### The Result Type
+Osprey has no exceptions, panics, or null. Any function that can fail returns a `Result`.
 
-**CRITICAL**: All functions that can fail **MUST** return a `Result` type. There are no exceptions, panics, or nulls. This is a core design principle of the language to ensure safety and eliminate entire classes of runtime errors.
+## The Result Type
 
-The `Result` type is a generic union type with two variants:
-
-- `Success { value: T }`: Represents a successful result, containing the value of type `T`.
-- `Error { message: E }`: Represents an error, containing an error message or object of type `E`.
-
-**Example:**
 ```osprey
 type Result<T, E> = Success { value: T } | Error { message: E }
 ```
 
-The compiler **MUST** enforce that `Result` types are always handled with a `match` expression, preventing direct access to the underlying value and ensuring that all possible outcomes are considered.
+The compiler rejects any direct access to the contained value. Callers must pattern-match the `Result` (see [Pattern Matching](0007-PatternMatching.md)):
 
-**Pattern Matching Results:**
 ```osprey
 let result = someFunctionThatCanFail()
 
 match result {
-    Success { value } => print("Success: ${value}")
-    Error { message } => print("Error: ${message}")
+    Success { value }   => print("Success: ${value}")
+    Error   { message } => print("Error: ${message}")
 }
 ```
 
-This approach guarantees that error handling is explicit, robust, and checked at compile time.
+## Arithmetic Returns Result
 
-### Arithmetic Operations and Result Types
+Every arithmetic operation returns `Result<T, MathError>` so overflow, underflow, and division by zero surface as values, not panics.
 
-All arithmetic operations return `Result<T, MathError>` to handle overflow, underflow, and division by zero:
+| Operator    | int, int                   | float, float               | int, float / float, int                   |
+| ----------- | -------------------------- | -------------------------- | ----------------------------------------- |
+| `+ - * %`   | `Result<int,   MathError>` | `Result<float, MathError>` | `Result<float, MathError>` (int promoted) |
+| `/`         | `Result<float, MathError>` | `Result<float, MathError>` | `Result<float, MathError>`                |
 
-**Operator Signatures:**
-- `+` Addition: `(int, int) -> Result<int, MathError>`
-- `-` Subtraction: `(int, int) -> Result<int, MathError>`
-- `*` Multiplication: `(int, int) -> Result<int, MathError>`
-- `/` Division: `(int, int) -> Result<float, MathError>` — always returns float
-- `%` Modulo: `(int, int) -> Result<int, MathError>`
-
-**Type Promotion:**
-- `int ⊕ int` → `Result<int, MathError>` (where ⊕ is +, -, *, %)
-- `float ⊕ float` → `Result<float, MathError>`
-- `int ⊕ float` → `Result<float, MathError>` (int promoted to float)
-- `int / int` → `Result<float, MathError>` (division always returns float)
-
-#### Arithmetic Examples
+`/` always yields `float`. There is no implicit `int`/`float` conversion outside this table; use `toFloat` and `toInt` for explicit conversion.
 
 ```osprey
-// ALL arithmetic returns Result types
-let sum = 1 + 3                    // Result<int, MathError> - could overflow
-let diff = 10 - 5                  // Result<int, MathError> - could underflow
-let product = 2 * 4                // Result<int, MathError> - could overflow
-let quotient = 10 / 2              // Result<float, MathError> - could divide by zero
-let remainder = 10 % 3             // Result<int, MathError> - could divide by zero
-
-// Float arithmetic also returns Result
-let fsum = 3.14 + 2.86             // Result<float, MathError>
-let fproduct = 2.5 * 4.0           // Result<float, MathError>
-
-// Type promotion
-let mixed = 10 + 5.5               // Result<float, MathError> (int promoted)
+let sum       = 1 + 3      // Result<int,   MathError>
+let quotient  = 10 / 3     // Result<float, MathError>
+let remainder = 10 % 3     // Result<int,   MathError>
+let mixed     = 10 + 5.5   // Result<float, MathError>
+let divZero   = 10 / 0     // Error(DivisionByZero)
 ```
 
-#### Working with Arithmetic Results
+#### Chaining Arithmetic
+
+Each operation returns a `Result`, so chaining requires either nested matches or, in the future, Result-aware operators:
 
 ```osprey
-// Must pattern match to extract values
-let calculation = 10 + 5           // Result<int, MathError>
-
-match calculation {
-    Success { value } => print("Result: ${value}")
-    Error { message } => print("Error: ${message}")
-}
-
-// Chaining arithmetic requires nested matches or Result operators
-let step1 = 10 + 5                 // Result<int, MathError>
+let step1 = 10 + 5
 match step1 {
-    Success { val1 } => {
-        let step2 = val1 * 2       // Result<int, MathError>
-        match step2 {
-            Success { val2 } => print("Final: ${val2}")
-            Error { message } => print("Multiplication error: ${message}")
-        }
+    Success { val1 } => match val1 * 2 {
+        Success { val2 }    => print("Final: ${val2}")
+        Error   { message } => print("Multiplication error: ${message}")
     }
     Error { message } => print("Addition error: ${message}")
 }
-
-// Printing Result types directly
-print(10 + 5)                      // Outputs: Success(15)
-print(10 / 0)                      // Outputs: Error(DivisionByZero)
 ```
 
-### Result Type toString Format
+### toString Format
 
-Result types convert to strings in the format `Success(value)` or `Error(message)`:
+A `Result` formats as `Success(<value>)` or `Error(<message>)`:
 
 ```osprey
-let divisionResult = 15 / 3              // Result<float, MathError>
-print(toString(divisionResult))          // "Success(5)"
-
-let divisionByZero = 10 / 0              // Result<float, MathError>
-print(toString(divisionByZero))          // "Error(DivisionByZero)"
-
-let calculation = 10 + 5                 // Result<int, MathError>
-print(toString(calculation))             // "Success(15)"
+print(toString(15 / 3))   // "Success(5)"
+print(toString(10 / 0))   // "Error(DivisionByZero)"
 ```
-
-This format is consistent across all Result types.

--- a/compiler/spec/0014-HTTP.md
+++ b/compiler/spec/0014-HTTP.md
@@ -1,530 +1,103 @@
 # HTTP
 
-🚀 **IMPLEMENTATION STATUS**: HTTP functions are implemented and working. WebSocket functions are implemented but undergoing testing. Fiber operations are partially implemented.
+HTTP server and client. Bodies are streamable; every operation that can fail returns `Result`. See [Error Handling](0013-ErrorHandling.md).
 
-### Table of Contents
-- [15. HTTP](#http)
-  - [Table of Contents](#table-of-contents)
-  - [15.1 HTTP Core Types](#http-core-types)
-    - [HTTP Method Union Type](#http-method-union-type)
-    - [HTTP Request Type (Immutable)](#http-request-type-immutable)
-    - [HTTP Response Type (Immutable with Streaming)](#http-response-type-immutable-with-streaming)
-  - [15.2 HTTP Server Functions](#http-server-functions)
-    - [`httpCreateServer(port: Int, address: String) -> Result<ServerID, String>`](#httpcreateserverport-int-address-string---resultserverid-string)
-    - [`httpListen(serverID: Int, handler: fn(String, String, String, String) -> HttpResponse) -> Result<Success, String>`](#httplistenserverid-int-handler-fnstring-string-string-string---httpresponse---resultsuccess-string)
-    - [`httpStopServer(serverID: Int) -> Result<Success, String>`](#httpstopserverserverid-int---resultsuccess-string)
-  - [15.2.1 HTTP Request Handling Bridge](#http-request-handling-bridge)
-    - [Request Handling Architecture](#request-handling-architecture)
-    - [Function Pointer Callbacks](#function-pointer-callbacks)
-    - [Callback Architecture Flow](#callback-architecture-flow)
-  - [15.3 HTTP Client Functions](#http-client-functions)
-    - [`httpCreateClient(baseUrl: String, timeout: Int) -> Result<ClientID, String>`](#httpcreateclientbaseurl-string-timeout-int---resultclientid-string)
-    - [`httpGet(clientID: Int, path: String, headers: String) -> Result<HttpResponse, String>`](#httpgetclientid-int-path-string-headers-string---resulthttpresponse-string)
-    - [`httpPost(clientID: Int, path: String, body: String, headers: String) -> Result<HttpResponse, String>`](#httppostclientid-int-path-string-body-string-headers-string---resulthttpresponse-string)
-    - [`httpPut(clientID: Int, path: String, body: String, headers: String) -> Result<HttpResponse, String>`](#httpputclientid-int-path-string-body-string-headers-string---resulthttpresponse-string)
-    - [`httpDelete(clientID: Int, path: String, headers: String) -> Result<HttpResponse, String>`](#httpdeleteclientid-int-path-string-headers-string---resulthttpresponse-string)
-    - [`httpRequest(clientID: Int, method: HttpMethod, path: String, headers: String, body: String) -> Result<HttpResponse, String>`](#httprequestclientid-int-method-httpmethod-path-string-headers-string-body-string---resulthttpresponse-string)
-    - [`httpCloseClient(clientID: Int) -> Result<Success, String>`](#httpcloseclientclientid-int---resultsuccess-string)
-  - [15.4 Complete HTTP Server Example](#complete-http-server-example)
+## Status
 
-Osprey provides first-class support for HTTP servers and clients, designed with performance, safety, and streaming as core principles. All HTTP functions follow Osprey's functional programming paradigms and comply with:
+Function signatures below are the specified interface. The current C runtime returns raw `int64_t` for the create/listen/stop and request functions; the type system expects `Result<T, string>` and the bridge is being aligned. The handler bridge in `httpListen` currently expects a raw string return rather than the `HttpResponse` record described here.
 
-- **RFC 7230**: HTTP/1.1 Message Syntax and Routing ([https://tools.ietf.org/html/rfc7230](https://tools.ietf.org/html/rfc7230))
-- **RFC 7231**: HTTP/1.1 Semantics and Content ([https://tools.ietf.org/html/rfc7231](https://tools.ietf.org/html/rfc7231))
-- **RFC 7232**: HTTP/1.1 Conditional Requests ([https://tools.ietf.org/html/rfc7232](https://tools.ietf.org/html/rfc7232))
-- **RFC 7233**: HTTP/1.1 Range Requests ([https://tools.ietf.org/html/rfc7233](https://tools.ietf.org/html/rfc7233))
-- **RFC 7234**: HTTP/1.1 Caching ([https://tools.ietf.org/html/rfc7234](https://tools.ietf.org/html/rfc7234))
-- **RFC 7235**: HTTP/1.1 Authentication ([https://tools.ietf.org/html/rfc7235](https://tools.ietf.org/html/rfc7235))
+## Types
 
-- **Result types** instead of exceptions for error handling
-- **Immutable response objects** that cannot be modified after creation
-- **Streaming by default** for large response bodies to prevent memory issues
-- **Fiber-based concurrency** for handling thousands of concurrent connections
-
-### HTTP Core Types
-
-#### HTTP Method Union Type
 ```osprey
 type HttpMethod = GET | POST | PUT | DELETE | PATCH | HEAD | OPTIONS
-```
 
-#### HTTP Request Type (Immutable)
-```osprey
 type HttpRequest = {
-    method: HttpMethod,
-    path: String,
-    headers: String,
-    body: String,
-    queryParams: String
+    method:      HttpMethod,
+    path:        string,
+    headers:     string,
+    body:        string,
+    queryParams: string
 }
-```
 
-#### HTTP Response Type (Immutable with Streaming - SIMPLIFIED!)
-```osprey
 type HttpResponse = {
-    status: Int,
-    headers: String,
-    contentType: String,
-    streamFd: Int,        // File descriptor for streaming
-    isComplete: Bool,     // Whether response is fully loaded
-    partialBody: String   // Body data (runtime auto-calculates length using strlen)
+    status:      int,
+    headers:     string,
+    contentType: string,
+    streamFd:    int,      // file descriptor for streaming; -1 if not streaming
+    isComplete:  bool,
+    partialBody: string    // length computed by the runtime; do not pass an explicit length
 }
+
+type ServerID = int
+type ClientID = int
 ```
 
-**IMPORTANT:** The `contentLength` and `partialLength` fields have been removed to prevent hardcoded length bugs. The C runtime automatically calculates string lengths using `strlen()` for security and simplicity.
+## Server Functions
 
-### HTTP Server Functions
-
-#### `httpCreateServer(port: Int, address: String) -> Result<ServerID, String>`
-
-Creates an HTTP server bound to the specified port and address.
-
-**Parameters:**
-- `port`: Port number (1-65535)
-- `address`: IP address to bind to (e.g., "127.0.0.1", "0.0.0.0")
-
-**Returns:**
-- `Success(serverID)`: Unique server identifier
-- `Err(message)`: Error description (invalid port, bind failure, etc.)
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<ServerID, String>`
-
-**Example:**
 ```osprey
-let serverResult = httpCreateServer(port: 8080, address: "127.0.0.1")
-match serverResult {
-    Success serverId => print("Server created with ID: ${serverId}")
-    Err message => print("Failed to create server: ${message}")
-}
+httpCreateServer(port: int, address: string) -> Result<ServerID, string>
+
+httpListen(
+    serverID: ServerID,
+    handler: fn(method: string, path: string, headers: string, body: string) -> HttpResponse
+) -> Result<unit, string>
+
+httpStopServer(serverID: ServerID) -> Result<unit, string>
 ```
 
-#### `httpListen(serverID: Int, handler: fn(String, String, String, String) -> HttpResponse) -> Result<Success, String>`
+The C runtime parses incoming requests and calls `handler` per request. All routing and application logic lives in Osprey; the C side provides only the transport.
 
-Starts the HTTP server listening for requests. Each request is handled in a separate fiber for maximum concurrency.
-
-**CRITICAL**: The handler function receives **structured HTTP request data** and must return an **HttpResponse object**. The C runtime handles HTTP parsing and response formatting.
-
-**Parameters:**
-- `serverID`: Server identifier from `httpCreateServer`
-- `handler`: Request handler function that takes:
-  - `method: String` - HTTP method (GET, POST, PUT, DELETE, etc.)
-  - `path: String` - Request path (e.g., "/api/users", "/health")
-  - `headers: String` - Raw HTTP headers as received
-  - `body: String` - Raw request body data
-
-**Returns:**
-- `Success()`: Server started successfully
-- `Err(message)`: Error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime expects raw string return from handler, not HttpResponse object. Also returns raw `int64_t` instead of `Result<Success, String>`
-
-**Example:**
 ```osprey
-fn handleHttpRequest(method: String, path: String, headers: String, body: String) -> HttpResponse = 
+fn handleRequest(method: string, path: string, headers: string, body: string) -> HttpResponse =
     match method {
         "GET" => match path {
-            "/health" => HttpResponse {
-                status: 200,
-                headers: "Content-Type: application/json",
-                contentType: "application/json",
-                streamFd: -1,
-                isComplete: true,
-                partialBody: "{\"status\": \"healthy\"}"
-            }
-            "/api/users" => HttpResponse {
-                status: 200,
-                headers: "Content-Type: application/json",
-                contentType: "application/json",
-                streamFd: -1,
-                isComplete: true,
-                partialBody: "{\"users\": [{\"id\": 1, \"name\": \"Alice\"}, {\"id\": 2, \"name\": \"Bob\"}]}"
-            }
-            _ => HttpResponse {
-                status: 404,
-                headers: "Content-Type: application/json",
-                contentType: "application/json",
-                streamFd: -1,
-                isComplete: true,
-                partialBody: "{\"error\": \"Not found\"}",
-            }
+            "/health" => jsonResponse(status: 200, body: "{\"status\":\"healthy\"}")
+            "/users"  => jsonResponse(status: 200, body: "{\"users\":[...]}")
+            _         => jsonResponse(status: 404, body: "{\"error\":\"not found\"}")
         }
         "POST" => match path {
-            "/api/users" => HttpResponse {
-                status: 201,
-                headers: "Content-Type: application/json",
-                contentType: "application/json",
-                streamFd: -1,
-                isComplete: true,
-                partialBody: "{\"id\": 3, \"name\": \"New User\", \"message\": \"User created successfully\"}",
-            }
-            _ => HttpResponse {
-                status: 404,
-                headers: "Content-Type: application/json",
-                contentType: "application/json",
-                streamFd: -1,
-                isComplete: true,
-                partialBody: "{\"error\": \"Not found\"}",
-            }
+            "/users" => jsonResponse(status: 201, body: "{\"id\":3}")
+            _        => jsonResponse(status: 404, body: "{\"error\":\"not found\"}")
         }
-        _ => HttpResponse {
-            status: 405,
-            headers: "Content-Type: application/json",
-            contentType: "application/json",
-            streamFd: -1,
-            isComplete: true,
-            partialBody: "{\"error\": \"Method not allowed\"}",
-        }
+        _ => jsonResponse(status: 405, body: "{\"error\":\"method not allowed\"}")
     }
 
-let listenResult = httpListen(serverID: serverId, handler: handleHttpRequest)
-match listenResult {
-    Success _ => print("Server started successfully")
-    Err message => print("Failed to start server: ${message}")
+fn jsonResponse(status: int, body: string) -> HttpResponse = HttpResponse {
+    status:      status,
+    headers:     "Content-Type: application/json",
+    contentType: "application/json",
+    streamFd:    -1,
+    isComplete:  true,
+    partialBody: body
+}
+
+match httpCreateServer(port: 8080, address: "127.0.0.1") {
+    Success { value: serverID } => httpListen(serverID: serverID, handler: handleRequest)
+    Error   { message }         => print("create failed: ${message}")
 }
 ```
 
-**HTTP Handler Architecture:**
+## Client Functions
 
-The HTTP server uses a **structured callback architecture** where:
-
-1. **C Runtime** handles TCP connections, HTTP parsing, and response formatting
-2. **Osprey Handler** receives structured request data and returns HttpResponse object
-3. **Type-safe abstraction** - handler works with HttpResponse types, not raw strings
-4. **Maximum performance** - direct function pointer callbacks with zero overhead
-
-**Handler Function Signature:**
 ```osprey
-fn myHandler(method: String, path: String, headers: String, body: String) -> HttpResponse
+httpCreateClient(baseUrl: string, timeout: int) -> Result<ClientID, string>
+
+httpGet(   clientID: ClientID, path: string,                            headers: string) -> Result<HttpResponse, string>
+httpPost(  clientID: ClientID, path: string, body: string,              headers: string) -> Result<HttpResponse, string>
+httpPut(   clientID: ClientID, path: string, body: string,              headers: string) -> Result<HttpResponse, string>
+httpDelete(clientID: ClientID, path: string,                            headers: string) -> Result<HttpResponse, string>
+httpRequest(clientID: ClientID, method: HttpMethod, path: string,
+            headers: string, body: string)                              -> Result<HttpResponse, string>
+
+httpCloseClient(clientID: ClientID) -> Result<unit, string>
 ```
 
-**Response Handling:**
-- Return HttpResponse object with complete response data
-- HTTP status codes are taken from the `status` field
-- Content-Type headers are taken from the `headers` or `contentType` fields
-- Response body is taken from `partialBody` field
-
-#### `httpStopServer(serverID: Int) -> Result<Success, String>`
-
-Stops the HTTP server and cleans up resources.
-
-**Parameters:**
-- `serverID`: Server identifier to stop
-
-**Returns:**
-- `Success()`: Server stopped successfully  
-- `Err(message)`: Error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<Success, String>`
-
-### HTTP Request Handling Bridge
-
-**CRITICAL REQUIREMENT**: HTTP servers in Osprey must call back into Osprey code to handle requests. **NO ROUTING LOGIC SHALL BE IMPLEMENTED IN C RUNTIME**. The C runtime provides only the transport layer; all application logic, routing, and request handling must be implemented in Osprey.
-
-#### Request Handling Architecture
-
-When an HTTP server receives a request, the C runtime must:
-
-1. **Parse the HTTP request** (method, path, headers, body)
-2. **Call the Osprey handler function** with structured data
-3. **Receive HttpResponse object** from Osprey
-4. **Send HTTP response** back to the client
-
-#### Function Pointer Callbacks
-
-When `httpListen()` is called, the Osprey handler function is passed directly to the C runtime as a function pointer:
-
-**C Runtime Function Signature:**
-```c
-int64_t http_listen(int64_t server_id, HttpRequestHandler handler);
-```
-
-**Handler Function Pointer Type:**
-```c
-typedef HttpResponse* (*HttpRequestHandler)(char* method, char* path, char* headers, char* body);
-```
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime expects `char*` return, not `HttpResponse*`
-
-#### Callback Architecture Flow
-
-**1. Osprey Code:**
 ```osprey
-fn handleHttpRequest(method: String, path: String, headers: String, body: String) -> HttpResponse = 
-    // ... handler implementation
-
-let listenResult = httpListen(serverId, handleHttpRequest)
-```
-
-**2. LLVM Code Generation:**
-- Generates function pointer for `handleHttpRequest`
-- Passes function pointer to `http_listen()` C function
-
-**3. C Runtime Implementation (Needs to be fixed):**
-```c
-// In request processing loop:
-void handle_client_request(int client_fd, char* method, char* path, char* headers, char* body) {
-    if (server->handler) {
-        // Call Osprey function directly
-        HttpResponse* response = server->handler(method, path, headers, body);
-        
-        // Format and send HTTP response using response object
-        char http_response[8192];
-        snprintf(http_response, sizeof(http_response),
-            "HTTP/1.1 %d %s\r\n"
-            "%s"
-            "Connection: close\r\n"
-            "\r\n",
-            response->status,
-            get_status_text(response->status),
-            response->headers ? response->headers : "");
-        
-        // Send headers and body
-        send(client_fd, http_response, strlen(http_response), 0);
-        send(client_fd, response->partialBody, response->partialLength, 0);
+match httpCreateClient(baseUrl: "http://api.example.com", timeout: 5000) {
+    Success { value: clientID } => match httpGet(clientID: clientID, path: "/users", headers: "") {
+        Success { value: response } => print("status: ${response.status}")
+        Error   { message }         => print("request failed: ${message}")
     }
+    Error { message } => print("client create failed: ${message}")
 }
 ```
-
-**Architecture Benefits:**
-- **Type safety**: Handler returns structured HttpResponse object
-- **Zero overhead**: Direct function calls, no serialization
-- **Complete control**: Osprey has full control over response format
-- **Simple debugging**: Direct call stack from C to Osprey
-- **Memory efficient**: No intermediate data structures
-
-### HTTP Client Functions
-
-#### `httpCreateClient(baseUrl: String, timeout: Int) -> Result<ClientID, String>`
-
-Creates an HTTP client for making requests.
-
-**Parameters:**
-- `baseUrl`: Base URL for requests (e.g., "http://api.example.com")
-- `timeout`: Request timeout in milliseconds
-
-**Returns:**
-- `Success(clientID)`: Unique client identifier
-- `Err(message)`: Error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<ClientID, String>`
-
-**Example:**
-```osprey
-let clientResult = httpCreateClient(baseUrl: "http://jsonplaceholder.typicode.com", timeout: 5000)
-match clientResult {
-    Success clientId => print("Client created with ID: ${clientId}")
-    Err message => print("Failed to create client: ${message}")
-}
-```
-
-#### `httpGet(clientID: Int, path: String, headers: String) -> Result<HttpResponse, String>`
-
-Makes an HTTP GET request.
-
-**Parameters:**
-- `clientID`: Client identifier from `httpCreateClient`
-- `path`: Request path (e.g., "/users/1")
-- `headers`: Additional headers (e.g., "Authorization: Bearer token\r\n")
-
-**Returns:**
-- `Success(response)`: HttpResponse object with status, headers, and body
-- `Err(message)`: Error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw status code `int64_t` instead of `Result<HttpResponse, String>`
-
-**Example:**
-```osprey
-let getResult = httpGet(clientID: clientId, path: "/users", headers: "")
-match getResult {
-    Success response => print("Request completed with status: ${response.status}")
-    Err message => print("Request failed: ${message}")
-}
-```
-
-#### `httpPost(clientID: Int, path: String, body: String, headers: String) -> Result<HttpResponse, String>`
-
-Makes an HTTP POST request with a request body.
-
-**Parameters:**
-- `clientID`: Client identifier
-- `path`: Request path
-- `body`: Request body data
-- `headers`: Additional headers
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw status code instead of `Result<HttpResponse, String>`
-
-**Example:**
-```osprey
-let postData = "{\"name\": \"John\", \"email\": \"john@example.com\"}"
-let headers = "Content-Type: application/json\r\n"
-let postResult = httpPost(clientID: clientId, path: "/users", body: postData, headers: headers)
-match postResult {
-    Success response => print("POST completed with status: ${response.status}")
-    Err message => print("POST failed: ${message}")
-}
-```
-
-#### `httpPut(clientID: Int, path: String, body: String, headers: String) -> Result<HttpResponse, String>`
-
-Makes an HTTP PUT request.
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw status code instead of `Result<HttpResponse, String>`
-
-#### `httpDelete(clientID: Int, path: String, headers: String) -> Result<HttpResponse, String>`
-
-Makes an HTTP DELETE request.
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw status code instead of `Result<HttpResponse, String>`
-
-#### `httpRequest(clientID: Int, method: HttpMethod, path: String, headers: String, body: String) -> Result<HttpResponse, String>`
-
-Generic HTTP request function for any HTTP method.
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw status code instead of `Result<HttpResponse, String>`
-
-#### `httpCloseClient(clientID: Int) -> Result<Success, String>`
-
-Closes the HTTP client and cleans up resources.
-
-**Returns:**
-- `Success()`: Client closed successfully
-- `Err(message)`: Error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<Success, String>`
-
-### Complete HTTP Server Example
-
-A practical HTTP server that demonstrates functional programming with HTTP functions:
-
-```osprey
-fn main() -> Int = {
-    let serverResult = httpCreateServer(8080, "127.0.0.1")
-    match serverResult {
-        Success serverId => {
-            print("Server created, starting listener...")
-            let listenResult = httpListen(serverId, handleRequest)
-            match listenResult {
-                Success _ => print("Server stopped")
-                Err message => print("Server error: ${message}")
-            }
-        }
-        Err message => print("Failed to create server: ${message}")
-    }
-    0
-}
-
-fn handleRequest(method: String, path: String, headers: String, body: String) -> HttpResponse = 
-    match method {
-        "GET" => match path {
-            "/health" => createHealthResponse()
-            "/users" => createUserListResponse()
-            "/api/stats" => createStatsResponse()
-            _ => createNotFoundResponse()
-        }
-        "POST" => match path {
-            "/users" => createUserFromBody(body)
-            "/api/data" => processDataFromBody(body)
-            _ => createNotFoundResponse()
-        }
-        "PUT" => match path {
-            "/users/1" => updateUserFromBody(body)
-            _ => createNotFoundResponse()
-        }
-        "DELETE" => match path {
-            "/users/1" => createDeleteResponse()
-            _ => createNotFoundResponse()
-        }
-        _ => createMethodNotAllowedResponse()
-    }
-
-fn createHealthResponse() -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"status\": \"healthy\"}",
-}
-
-fn createUserListResponse() -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"users\": [{\"id\": 1, \"name\": \"Alice\"}, {\"id\": 2, \"name\": \"Bob\"}]}",
-}
-
-fn createNotFoundResponse() -> HttpResponse = HttpResponse {
-    status: 404,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"error\": \"Not found\"}",
-}
-
-fn createMethodNotAllowedResponse() -> HttpResponse = HttpResponse {
-    status: 405,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"error\": \"Method not allowed\"}",
-}
-
-fn createUserFromBody(body: String) -> HttpResponse = HttpResponse {
-    status: 201,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"id\": 3, \"name\": \"New User\", \"message\": \"User created successfully\"}",
-}
-
-fn updateUserFromBody(body: String) -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"id\": 1, \"name\": \"Alice Updated\", \"message\": \"User updated successfully\"}",
-}
-
-fn createDeleteResponse() -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"message\": \"User deleted successfully\"}",
-}
-
-fn processDataFromBody(body: String) -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"processed\": true, \"length\": ${length(body)}}",
-}
-
-fn createStatsResponse() -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "{\"server\": \"osprey\", \"version\": \"1.0\", \"uptime\": \"3600\"}",
-}
-```
-
-This example demonstrates:
-
-- **HttpResponse object handling** with complete response structure
-- **Functional programming patterns** using pattern matching for routing
-- **Type-safe HTTP responses** with structured data
-- **Modular design** with separate functions for different operations
-- **Error handling** through the Result type system
-- **Real-world API patterns** (CRUD operations, health checks, stats)
-

--- a/compiler/spec/0015-WebSockets.md
+++ b/compiler/spec/0015-WebSockets.md
@@ -1,372 +1,88 @@
-# WebSocket Functions
+# WebSockets
 
-🔒 **IMPLEMENTATION STATUS**: WebSocket functions are implemented with security features but have critical design flaws that violate Osprey's functional programming principles.
+Bidirectional WebSocket communication over RFC 6455. Every operation that can fail returns `Result`; see [Error Handling](0013-ErrorHandling.md).
 
-### Table of Contents
-- [16. WebSocket Functions](#websocket-functions)
-  - [Table of Contents](#table-of-contents)
-  - [16.1 WebSocket Core Types](#websocket-core-types)
-  - [16.2 WebSocket Security Implementation](#websocket-security-implementation)
-  - [16.3 WebSocket Client Functions](#websocket-client-functions)
-    - [`websocketConnect(url: String, messageHandler: fn(String) -> Result<Success, String>) -> Result<WebSocketID, String>`](#websocketconnecturl-string-messagehandler-fnstring---resultsuccess-string---resultwebsocketid-string)
-    - [`websocketSend(wsID: Int, message: String) -> Result<Success, String>`](#websocketsendwsid-int-message-string---resultsuccess-string)
-    - [`websocketClose(wsID: Int) -> Result<Success, String>`](#websocketclosewsid-int---resultsuccess-string)
-  - [16.4 WebSocket Server Functions](#websocket-server-functions)
-    - [`websocketCreateServer(port: Int, address: String, path: String) -> Result<ServerID, String>`](#websocketcreateserverport-int-address-string-path-string---resultserverid-string)
-    - [`websocketServerListen(serverID: Int) -> Result<Success, String>`](#websocketserverlistenserverid-int---resultsuccess-string)
-    - [`websocketServerBroadcast(serverID: Int, message: String) -> Result<Success, String>`](#websocketserverbroadcastserverid-int-message-string---resultsuccess-string)
-    - [`websocketStopServer(serverID: Int) -> Result<Success, String>`](#websocketstopserverserverid-int---resultsuccess-string)
-  - [16.5 Complete WebSocket Example](#complete-websocket-example)
+## Status
 
-WebSockets provide real-time, bidirectional communication between client and server. Osprey implements WebSocket support following functional programming principles with comprehensive error handling through Result types.
+Function signatures below are the specified interface. The current C runtime returns raw `int64_t` for several of these functions; the type system expects `Result<T, string>` and the bridge is being aligned. WebSocket server `listen` currently fails to bind in some environments.
 
-All WebSocket functions comply with:
-- **RFC 6455**: The WebSocket Protocol ([https://tools.ietf.org/html/rfc6455](https://tools.ietf.org/html/rfc6455))
-- **Result types** for all operations that can fail
-- **Immutable message handling** with functional callbacks
-- **Type safety** through structured error handling
-
-## WebSocket Core Types
+## Types
 
 ```osprey
-type WebSocketID = Int
-type ServerID = Int
+type WebSocketID = int
+type ServerID    = int
 
 type WebSocketMessage = {
-    type: String,
-    data: String,
-    timestamp: Int
+    type:      string,
+    data:      string,
+    timestamp: int
 }
 
 type WebSocketConnection = {
-    id: WebSocketID,
-    url: String,
-    isConnected: Bool
+    id:          WebSocketID,
+    url:         string,
+    isConnected: bool
 }
 ```
 
-## WebSocket Security Implementation
+## Client Functions
 
-Osprey's WebSocket implementation follows **OWASP WebSocket Security Guidelines** with multiple security layers:
-
-**🛡️ Cryptographic Security:**
-- **OpenSSL SHA-1**: RFC 6455 compliant WebSocket handshake
-- **Secure key validation**: 24-character base64 key format validation
-- **Memory clearing**: All sensitive data zeroed before deallocation
-
-**⚔️ Input Validation:**
-- **WebSocket key format validation**: Strict RFC 6455 compliance
-- **Buffer length validation**: Maximum limits prevent DoS attacks
-- **Memory boundary checking**: No buffer overruns possible
-
-## WebSocket Client Functions
-
-#### `websocketConnect(url: String, messageHandler: fn(String) -> Result<Success, String>) -> Result<WebSocketID, String>`
-
-Establishes a WebSocket connection with a message handler callback.
-
-**Parameters:**
-- `url`: WebSocket URL (e.g., "ws://localhost:8080/chat")
-- `messageHandler`: Callback function to handle incoming messages
-
-**Returns:**
-- `Success(wsID)`: WebSocket connection identifier
-- `Err(message)`: Connection error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<WebSocketID, String>` and takes string handler instead of function pointer
-
-**Example:**
 ```osprey
-fn handleMessage(message: String) -> Result<Success, String> = {
-    print("Received: ${message}")
-    Success()
+websocketConnect(
+    url: string,
+    messageHandler: fn(string) -> Result<unit, string>
+) -> Result<WebSocketID, string>
+
+websocketSend(wsID: WebSocketID, message: string) -> Result<unit, string>
+websocketClose(wsID: WebSocketID)                  -> Result<unit, string>
+```
+
+`messageHandler` is invoked once per incoming frame with the frame payload.
+
+```osprey
+fn handleMessage(msg: string) -> Result<unit, string> = {
+    print("received: ${msg}")
+    Success { value: () }
 }
 
-let wsResult = websocketConnect(url: "ws://localhost:8080/chat", messageHandler: handleMessage)
-match wsResult {
-    Success wsId => {
-        print("Connected with ID: ${wsId}")
-        // Use the connection
+match websocketConnect(url: "ws://localhost:8080/chat", messageHandler: handleMessage) {
+    Success { value: wsID } => {
+        websocketSend(wsID: wsID, message: "hello")
+        websocketClose(wsID: wsID)
     }
-    Err message => print("Failed to connect: ${message}")
+    Error { message } => print("connect failed: ${message}")
 }
 ```
 
-#### `websocketSend(wsID: Int, message: String) -> Result<Success, String>`
+## Server Functions
 
-Sends a message through the WebSocket connection.
-
-**Parameters:**
-- `wsID`: WebSocket identifier from `websocketConnect`
-- `message`: Message to send
-
-**Returns:**
-- `Success()`: Message sent successfully
-- `Err(message)`: Send error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<Success, String>`
-
-**Example:**
 ```osprey
-let sendResult = websocketSend(wsID: wsId, message: "Hello, WebSocket!")
-match sendResult {
-    Success _ => print("Message sent successfully")
-    Err message => print("Failed to send: ${message}")
-}
+websocketCreateServer(
+    port: int, address: string, path: string
+) -> Result<ServerID, string>
+
+websocketServerListen(serverID: ServerID)                         -> Result<unit, string>
+websocketServerSend(serverID: ServerID, wsID: WebSocketID,
+                    message: string)                              -> Result<unit, string>
+websocketServerBroadcast(serverID: ServerID, message: string)     -> Result<unit, string>
+websocketStopServer(serverID: ServerID)                           -> Result<unit, string>
 ```
 
-#### `websocketClose(wsID: Int) -> Result<Success, String>`
-
-Closes the WebSocket connection and cleans up resources.
-
-**Parameters:**
-- `wsID`: WebSocket identifier to close
-
-**Returns:**
-- `Success()`: Connection closed successfully
-- `Err(message)`: Close error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<Success, String>`
-
-**Example:**
-```osprey
-let closeResult = websocketClose(wsID: wsId)
-match closeResult {
-    Success _ => print("Connection closed")
-    Err message => print("Failed to close: ${message}")
-}
-```
-
-## WebSocket Server Functions
-
-#### `websocketCreateServer(port: Int, address: String, path: String) -> Result<ServerID, String>`
-
-Creates a WebSocket server bound to the specified port, address, and path.
-
-**Parameters:**
-- `port`: Port number (1-65535)
-- `address`: IP address to bind to (e.g., "127.0.0.1", "0.0.0.0")
-- `path`: WebSocket endpoint path (e.g., "/chat", "/live")
-
-**Returns:**
-- `Success(serverID)`: Unique WebSocket server identifier
-- `Err(message)`: Server creation error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<ServerID, String>`. Also has critical runtime issues with port binding failures.
-
-**Example:**
-```osprey
-let serverResult = websocketCreateServer(port: 8080, address: "127.0.0.1", path: "/chat")
-match serverResult {
-    Success serverId => print("WebSocket server created with ID: ${serverId}")
-    Err message => print("Failed to create server: ${message}")
-}
-```
-
-#### `websocketServerListen(serverID: Int) -> Result<Success, String>`
-
-Starts the WebSocket server listening for connections.
-
-**Parameters:**
-- `serverID`: Server identifier from `websocketCreateServer`
-
-**Returns:**
-- `Success()`: Server started listening successfully
-- `Err(message)`: Listen error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<Success, String>`. Currently returns `-4` (bind failed) due to port binding issues.
-
-**Example:**
-```osprey
-let listenResult = websocketServerListen(serverID: serverId)
-match listenResult {
-    Success _ => print("Server listening on ws://127.0.0.1:8080/chat")
-    Err message => print("Failed to start listening: ${message}")
-}
-```
-
-#### `websocketServerBroadcast(serverID: Int, message: String) -> Result<Success, String>`
-
-Broadcasts a message to all connected WebSocket clients.
-
-**Parameters:**
-- `serverID`: Server identifier
-- `message`: Message to broadcast to all clients
-
-**Returns:**
-- `Success()`: Message broadcasted successfully
-- `Err(message)`: Broadcast error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` (number of clients sent to) instead of `Result<Success, String>`
-
-**Example:**
-```osprey
-let broadcastResult = websocketServerBroadcast(serverID: serverId, message: "Welcome to Osprey Chat!")
-match broadcastResult {
-    Success _ => print("Message broadcasted to all clients")
-    Err message => print("Failed to broadcast: ${message}")
-}
-```
-
-#### `websocketStopServer(serverID: Int) -> Result<Success, String>`
-
-Stops the WebSocket server and closes all connections.
-
-**Parameters:**
-- `serverID`: Server identifier to stop
-
-**Returns:**
-- `Success()`: Server stopped successfully
-- `Err(message)`: Stop error description
-
-**Implementation Status:** ⚠️ **INCORRECT** - Current C runtime returns raw `int64_t` instead of `Result<Success, String>`
-
-**Example:**
-```osprey
-let stopResult = websocketStopServer(serverID: serverId)
-match stopResult {
-    Success _ => print("Server stopped successfully")
-    Err message => print("Failed to stop server: ${message}")
-}
-```
-
-## Complete WebSocket Example
-
-A practical WebSocket server and client implementation demonstrating real-time communication:
+## Server Example
 
 ```osprey
-fn main() -> Int = {
-    print("Starting WebSocket chat server...")
-    
-    // Create WebSocket server
-    let serverResult = websocketCreateServer(port: 8080, address: "127.0.0.1", path: "/chat")
-    
-    match serverResult {
-        Success serverId => {
-            print("WebSocket server created with ID: ${serverId}")
-            
-            // Start listening for connections
-            let listenResult = websocketServerListen(serverID: serverId)
-            
-            match listenResult {
-                Success _ => {
-                    print("Server listening on ws://127.0.0.1:8080/chat")
-                    
-                    // Broadcast welcome message
-                    let welcomeResult = websocketServerBroadcast(
-                        serverID: serverId, 
-                        message: "Welcome to Osprey Chat!"
-                    )
-                    
-                    match welcomeResult {
-                        Success _ => print("Welcome message broadcasted")
-                        Err message => print("Failed to broadcast welcome: ${message}")
-                    }
-                    
-                    // Keep server alive for 10 seconds
-                    sleep(10000)
-                    
-                    // Clean shutdown
-                    let stopResult = websocketStopServer(serverID: serverId)
-                    match stopResult {
-                        Success _ => print("Server stopped successfully")
-                        Err message => print("Failed to stop server: ${message}")
-                    }
-                }
-                Err message => print("Failed to start listening: ${message}")
+fn main() -> int = {
+    match websocketCreateServer(port: 8080, address: "127.0.0.1", path: "/chat") {
+        Success { value: serverID } => match websocketServerListen(serverID: serverID) {
+            Success { value: _ } => {
+                websocketServerBroadcast(serverID: serverID, message: "Welcome!")
+                sleep(10000)
+                websocketStopServer(serverID: serverID)
+                0
             }
+            Error { message } => { print("listen failed: ${message}"); 1 }
         }
-        Err message => print("Failed to create server: ${message}")
+        Error { message } => { print("create failed: ${message}"); 1 }
     }
-    
-    0
 }
-
-// WebSocket client example
-fn connectToChat() -> Int = {
-    fn chatMessageHandler(message: String) -> Result<Success, String> = {
-        print("Chat: ${message}")
-        
-        // Process different message types
-        match message {
-            "ping" => {
-                print("Received ping, responding with pong")
-                Success()
-            }
-            _ => {
-                print("Received message: ${message}")
-                Success()
-            }
-        }
-    }
-    
-    let wsResult = websocketConnect(
-        url: "ws://127.0.0.1:8080/chat", 
-        messageHandler: chatMessageHandler
-    )
-    
-    match wsResult {
-        Success wsId => {
-            print("Connected to chat server with ID: ${wsId}")
-            
-            // Send some messages
-            let sendResult1 = websocketSend(wsID: wsId, message: "Hello from Osprey!")
-            match sendResult1 {
-                Success _ => print("First message sent")
-                Err message => print("Failed to send first message: ${message}")
-            }
-            
-            let sendResult2 = websocketSend(wsID: wsId, message: "How is everyone?")
-            match sendResult2 {
-                Success _ => print("Second message sent")
-                Err message => print("Failed to send second message: ${message}")
-            }
-            
-            let pingResult = websocketSend(wsID: wsId, message: "ping")
-            match pingResult {
-                Success _ => print("Ping sent")
-                Err message => print("Failed to send ping: ${message}")
-            }
-            
-            // Wait a bit before closing
-            sleep(2000)
-            
-            // Close connection
-            let closeResult = websocketClose(wsID: wsId)
-            match closeResult {
-                Success _ => print("Disconnected from chat")
-                Err message => print("Failed to disconnect: ${message}")
-            }
-        }
-        Err message => print("Failed to connect: ${message}")
-    }
-    
-    0
-}
-
-// Chat message processing with pattern matching
-fn processMessage(message: String) -> Result<String, String> = 
-    match message {
-        "{\"type\":\"join\"}" => Success("User joined the chat")
-        "{\"type\":\"leave\"}" => Success("User left the chat")
-        "{\"type\":\"message\"}" => Success("Regular chat message")
-        _ => Success("Unknown message type")
-    }
 ```
-
-This example demonstrates:
-
-- **Result type error handling** for all WebSocket operations
-- **Functional message handlers** with proper callback signatures
-- **Pattern matching** for different message types
-- **Resource management** with proper connection cleanup
-- **Real-time communication** patterns for chat applications
-- **Comprehensive error handling** following Osprey's functional principles
-- **Type-safe WebSocket operations** with structured error messages
-
-**Key Differences from Current Implementation:**
-1. **All functions return Result types** instead of raw integers
-2. **Message handlers are proper function pointers** instead of string identifiers
-3. **Comprehensive error handling** with descriptive error messages
-4. **Functional programming patterns** with immutable message processing
-5. **Type safety** through structured return types and pattern matching

--- a/compiler/spec/0016-SecurityAndSandboxing.md
+++ b/compiler/spec/0016-SecurityAndSandboxing.md
@@ -1,15 +1,6 @@
 # Security and Sandboxing
 
-- [Security Flags](#security-flags)
-- [Security Policies](#security-policies)
-- [Blocked Functions by Category](#blocked-functions-by-category)
-- [Function Availability](#function-availability)
-- [Programming Best Practices](#programming-best-practices)
-- [Implementation Details](#implementation-details)
-
-## Security and Sandboxing
-
-The Osprey compiler includes built-in security controls to restrict access to potentially dangerous functionality like network operations and file system access. This is essential for safe code execution in environments like web compilers where untrusted code may be executed.
+The compiler can disable categories of built-in functions at compile time. Restricted functions are not lowered into the program at all — calls to them produce "undefined function" compile errors. There is no runtime overhead.
 
 ## Security Flags
 
@@ -47,18 +38,6 @@ osprey program.osp --no-http --no-websocket --run
 osprey program.osp --no-fs --llvm
 ```
 
-## Security Policies
-
-#### Default Security (Permissive)
-By default, all operations are allowed for backward compatibility and normal development use.
-
-#### Sandbox Security (Restrictive)
-When `--sandbox` is used, all potentially dangerous functions are unavailable. This is recommended for:
-- Web-based code execution
-- Untrusted code evaluation
-- Educational environments
-- Code review systems
-
 ## Blocked Functions by Category
 
 #### HTTP Functions
@@ -93,82 +72,13 @@ When file system access is disabled (`--no-fs` or `--sandbox`), these functions 
 - `createDirectory` - Create directory
 - `listDirectory` - List directory contents
 
-## Function Availability
+## Compiler Output
 
-In different security modes, certain functions are simply not available in the language:
+When restrictions are active the compiler prints a summary line:
 
-**Sandbox Mode**: Only safe functions like `print`, `toString`, `range`, etc. are available. Dangerous functions like `httpCreateServer` or `websocketConnect` result in "undefined function" compile errors.
-
-**Partial Restrictions**: When specific categories are disabled (e.g., `--no-http`), those functions are unavailable while others remain accessible.
-
-**Default Mode**: All functions are available.
-- A human-readable explanation
-
-## Programming Best Practices
-
-#### For Safe Code
-Write code that doesn't use security-sensitive functions:
-```osprey
-// Safe operations - work in all security modes
-let x = 42
-let y = 24
-let sum = x + y
-print("Sum: ")
-print(sum)
 ```
-
-#### For Network Code
-When writing network code, be aware that it may be restricted:
-```osprey
-// This will fail in sandbox mode or with --no-http
-let serverID = httpCreateServer(port: 8080, address: "127.0.0.1")
-```
-
-## Implementation Details
-
-#### Security Configuration
-Security settings are configured at compilation time and cannot be bypassed by the compiled program. The security checks happen during the LLVM IR generation phase, preventing security-sensitive functions from being included in the generated code.
-
-#### Performance Impact
-Security checks add minimal overhead during compilation and no runtime overhead, as restricted functions are simply not compiled into the final program.
-
-#### Backward Compatibility
-All existing code continues to work with default settings. Security restrictions are opt-in and don't affect normal development workflows.
-
-#### Integration with Web Compiler
-The security features are designed specifically for web compiler integration:
-
-```javascript
-// Example web compiler usage
-const result = await compileOsprey(sourceCode, {
-    mode: 'sandbox',  // Enable sandbox mode
-    outputFormat: 'llvm'
-});
-```
-
-#### Security Summary
-When using security restrictions, the compiler will display a security summary:
-
-```bash
-# Sandbox mode
 Security: SANDBOX MODE - All risky operations disabled
-
-# Partial restrictions
 Security: Allowed=[FileRead,FileWrite,FFI] Blocked=[HTTP,WebSocket]
 ```
 
----
-
-## Summary
-
-Osprey is a modern functional programming language with:
-
-- **Type Safety**: No runtime panics, all errors handled explicitly via Result types
-- **Named Arguments**: Multi-parameter functions require named arguments for clarity
-- **Functional Programming**: Powerful iterator functions with pipe operator
-- **Lightweight Fibers**: Zero-cost concurrency with Rust-like async/await
-- **Fiber-Isolated Modules**: No global state, each fiber gets its own module instances
-- **Rust Interoperability**: Seamless integration with Rust libraries
-- **Memory Safety**: No shared mutable state between fibers
-
-**Key Innovation**: The fiber-isolated module system eliminates data races by design while maintaining clean encapsulation through accessor patterns.
+Restrictions cannot be bypassed by the compiled program; the relevant runtime functions are never linked in.

--- a/compiler/spec/0017-AlgebraicEffects.md
+++ b/compiler/spec/0017-AlgebraicEffects.md
@@ -1,234 +1,107 @@
-## Algebraic Effects
+# Algebraic Effects
 
-**Based on Plotkin & Pretnar's foundational work on algebraic effects and handlers**
+Osprey treats effects as first-class language features. An effect declares a set of operations; functions list the effects they may perform; handlers give meaning to operations. The compiler rejects any program that performs an unhandled effect.
 
-Osprey has a first class effects system.
+## Status
 
-### IMPLEMENTATION STATUS
+Effect declarations, `perform` expressions, effect annotations on function types, handler parsing, and full compile-time unhandled-effect checking are implemented. Continuation/`resume` semantics inside handlers are not yet implemented; current handlers act as value substitutions, which is sufficient for many uses but does not yet model the full algebraic-effects calculus.
 
-**PARTIALLY IMPLEMENTED** - Effect declarations, perform expressions, and **COMPILE-TIME SAFETY** are fully working! Handler expressions parsing is implemented but handler execution needs completion.
-
-### Theoretical Foundation
-
-Algebraic effects are computational effects that can be represented by:
-1. **A set of operations** that produce the effects
-2. **An equational theory** for these operations that describes their properties
-
-Each computation either:
-- **Returns a value**, or  
-- **Performs an operation** with an outcome that determines a continuation
-
-The **free model** of the equational theory generates the computational monad for the effect. Handlers provide **models of the theory**, and handling applies the **unique homomorphism** from the free model to the handler model.
-
-**Key insight from Plotkin & Pretnar**: Handlers are **effect deconstructors** that provide interpretations, while operations are **effect constructors** that produce effects.
-
-### New Keywords
+## Keywords
 
 ```
-effect perform handler with do
+effect perform handle in
 ```
 
-### Effect Declarations
-
-An effect declares a set of operations in the algebraic theory:
+## Effect Declarations
 
 ```ebnf
-effectDecl   ::= docComment? "effect" IDENT "{" opDecl* "}"
-opDecl       ::= IDENT ":" fnType
+effectDecl ::= docComment? "effect" IDENT "{" opDecl* "}"
+opDecl     ::= IDENT ":" fnType
 ```
-
-Example:
 
 ```osprey
 effect State {
-  get : fn() -> Int
-  set : fn(Int) -> Unit  
+    get : fn() -> int
+    set : fn(int) -> unit
 }
 ```
 
-This declares a **State** effect with operations `get` and `set`. No equations are specified (free theory).
+## Effectful Function Types
 
-### Effectful Function Types
-
-Functions declare their effect dependencies with `!EffectSet`:
+A function declares the effects it may perform with `!E` after its return type. `E` is either a single effect or a bracketed set.
 
 ```osprey
-fn read() -> String !IO = perform IO.readLine()
-
-fn fetch(url: String) -> String ![IO, Net] = ...
+fn read() -> string !IO = perform IO.readLine()
+fn fetch(url: string) -> string ![IO, Net] = ...
 ```
 
-The effect annotation declares that this function may perform operations from the specified effects.
+A function with no `!E` is pure; calling an effectful function from a pure context is a compilation error.
 
-### Performing Operations
+## Performing Operations
 
+```ebnf
+performExpr ::= "perform" IDENT "." IDENT "(" args? ")"
 ```
-perform EffectName.operation(args...)
-```
 
-**Performing an operation** suspends the computation at that point. The operation takes arguments representing possible continuations.
-
-Example:
 ```osprey
-fn incrementTwice() -> Int !State = {
-  let current = perform State.get()
-  perform State.set(current + 1)  
-  perform State.get()
+fn incrementTwice() -> int !State = {
+    let current = perform State.get()
+    perform State.set(current + 1)
+    perform State.get()
 }
 ```
 
-**CRITICAL COMPILE-TIME SAFETY**: If no handler intercepts the call, the compiler produces a **compilation error**. Unhandled effects are **NEVER** permitted at runtime.
+If no enclosing handler covers an effect, the program does not compile.
 
-### Handlers - Models of the Effect Theory
-
-A handler provides a **model** of the effect theory by specifying how each operation should be interpreted:
+## Handlers
 
 ```ebnf
 handlerExpr ::= "handle" IDENT handlerArm+ "in" expr
 handlerArm  ::= IDENT paramList? "=>" expr
 ```
 
-Example:
-
 ```osprey
 handle State
-  get => 42
-  set newVal => print "Setting state to: " + toString newVal
+    get        => 42
+    set newVal => print("set to " + toString(newVal))
 in
-  incrementTwice()
+    incrementTwice()
 ```
 
-**Handler Semantics**: The handler provides a model where:
-- `get()` is interpreted as returning `42`
-- `set(newVal)` is interpreted as printing the new value
-
-The `handle...in` construct applies the **unique homomorphism** from the free model (where `incrementTwice` lives) to the handler model.
-
-### Handler Correctness
-
-From Plotkin & Pretnar: A handler is **correct** if its interpretation holds in the corresponding model of the effect theory.
-
-In Osprey:
-- **Static verification** ensures all performed operations have handlers
-- **Type checking** ensures handler signatures match operation signatures  
-- **Effect inference** computes minimal effect sets for expressions
-
-### Nested Handlers and Composition
-
-Handlers can be nested. The **innermost handler** wins for each effect:
+The innermost matching handler wins for each effect. Handlers may be nested freely:
 
 ```osprey
 handle Logger
-  log msg => print "[OUTER] " + msg
+    log msg => print("[OUTER] " + msg)
 in
-  handle Logger
-    log msg => print "[INNER] " + msg  // This handler takes precedence
-  in
-    perform Logger.log "test"  // Prints "[INNER] test"
+    handle Logger
+        log msg => print("[INNER] " + msg)
+    in
+        perform Logger.log("test")    // prints "[INNER] test"
 ```
 
-### Effect Sets and Inference
+## Effect Inference
 
-* The compiler **infers the minimal effect set** for every expression
-* Functions must **declare** their effects or be **pure**  
-* **Effect polymorphism**: Functions can be polymorphic over effects
+The compiler infers the minimal effect set of every expression. Functions either declare their effects or are required to be pure. A function may be polymorphic over an effect set:
 
 ```osprey
-fn loggedCalculation<E>(x: Int) -> Int !E = {
-  perform Logger.log("Calculating...")  // E must include Logger
-  x * 2
+fn loggedCalculation<E>(x: int) -> int !E = {
+    perform Logger.log("calculating")     // E must include Logger
+    x * 2
 }
 ```
 
-### Compilation Model
+## Static Safety Checks
 
-1. **Effect Verification**: Front-end verifies all effects are handled
-2. **Handler Registration**: Build handler stack during type checking
-3. **Operation Resolution**: Each `perform` resolves to its handler
-4. **Code Generation**: Generate efficient handler dispatch
+The compiler enforces three static checks on effect programs. Each failure is a compile-time error, not a runtime fault.
 
-Unhandled effects cause compile-time errors, ensuring safety.
+| Check                              | Failure mode in other languages |
+| ---------------------------------- | ------------------------------- |
+| Every `perform` has a handler      | Runtime crash / unhandled exn   |
+| No circular effect dependency      | Stack overflow                  |
+| No handler that performs the same effect it handles | Infinite loop |
 
-### Comparison with Research
-
-| Aspect                | Plotkin & Pretnar Theory | Osprey Implementation     |
-| --------------------- | ------------------------ | ------------------------- |
-| **Effect Operations** | Free algebraic theory    | `effect` declarations     |
-| **Handlers**          | Models of the theory     | `handle...in` expressions |
-| **Handling**          | Unique homomorphisms     | Compile-time dispatch     |
-| **Safety**            | Theoretical correctness  | Compile-time verification |
-
-### Examples
-
-```osprey
-effect Exception {
-  raise : fn(String) -> Unit  
-}
-
-effect State {
-  get : fn() -> Int
-  set : fn(Int) -> Unit
-}
-
-// Pure function
-fn double(x: Int) -> Int = x * 2
-
-// Effectful function
-fn safeDivide(a: Int, b: Int) -> Int ![Exception, State] = {
-  if b == 0 then {
-    perform Exception.raise("Division by zero")  
-    0  // Never reached
-  } else {
-    let result = a / b
-    perform State.set(result)
-    result
-  }
-}
-
-// Handler providing exception model
-handle Exception
-  raise msg => 
-    print "Error: " + msg
-    -1  // Recovery value
-in
-  handle State
-    get => 0
-    set newVal => print "State: " + toString newVal
-  in
-    let result = safeDivide 10 0
-    print "Result: " + toString result
-```
-
----
-
-## Compile-Time Effect Verification
-
-Osprey provides complete compile-time safety for algebraic effects. Unhandled effects produce compilation errors, not runtime failures:
-
-```osprey
-effect Logger { log: fn(string) -> unit }
-
-fn main() -> unit = {
-    perform Logger.log("This will fail compilation!")  // Compilation error
-}
-```
-
-**Error**: Unhandled effect 'Logger.log' - all effects must be explicitly handled or forwarded in function signatures.
-
-### Comparison with Other Effect Systems
-
-| System        | Theoretical Basis | Runtime Safety | Compile-time Safety       |
-| ------------- | ----------------- | -------------- | ------------------------- |
-| OCaml Effects | Plotkin & Pretnar | Crashes        | No verification           |
-| Eff Language  | Plotkin & Pretnar | Exceptions     | Partial checking          |
-| Koka Effects  | Plotkin & Pretnar | Aborts         | Effect inference          |
-| Osprey        | Plotkin & Pretnar | Safe           | Complete verification     |
-
-Osprey extends the theoretical foundation with complete static verification, effect inference, efficient compilation, and composable handlers.
-
-## Circular Dependency Detection
-
-Osprey detects circular effect dependencies at compile time:
+### Circular Dependency Example
 
 ```osprey
 effect StateA { getFromB: fn() -> int }
@@ -237,178 +110,54 @@ effect StateB { getFromA: fn() -> int }
 fn circularA() -> int !StateA = perform StateA.getFromB()
 fn circularB() -> int !StateB = perform StateB.getFromA()
 
-fn main() -> Unit = 
-    handle StateA
-        getFromB => circularB  // ❌ CIRCULAR DEPENDENCY!
+handle StateA
+    getFromB => circularB()       // ❌ circular dependency
+in
+    handle StateB
+        getFromA => circularA()   // ❌ circular dependency
     in
-      handle StateB
-          getFromA => circularA  // ❌ CIRCULAR DEPENDENCY!
-      in
-          circularA  // Would cause infinite recursion
+        circularA()
 ```
 
-**Error**: Circular effect dependency detected - handler StateA.getFromB calls function that performs StateB.getFromA, which is handled by calling StateA.getFromB (infinite recursion detected)
-
-### Infinite Handler Recursion Detection
+### Handler-Self-Recursion Example
 
 ```osprey
 effect Counter { increment: fn(int) -> int }
 
 fn performIncrement(n: int) -> int !Counter = perform Counter.increment(n)
 
-fn main() -> Unit = 
-    handle Counter
-        increment n => performIncrement (n + 1)  // ❌ INFINITE RECURSION!
-    in
-        performIncrement 5  // Would cause stack overflow
+handle Counter
+    increment n => performIncrement(n + 1)   // ❌ handler performs the effect it handles
+in
+    performIncrement(5)
 ```
 
-**Error**: Infinite handler recursion detected - handler Counter.increment calls function that performs the same effect it handles (infinite recursion detected)
+## Worked Example
 
-### Safety Guarantees
+`x * 2` returns `Result<int, MathError>`; the function below performs `Exception` on overflow and `State` to record the success.
 
-| Safety Check          | Osprey         | Other Languages |
-| --------------------- | -------------- | --------------- |
-| Unhandled Effects     | Compile Error  | Runtime Crash   |
-| Circular Dependencies | Compile Error  | Stack Overflow  |
-| Handler Recursion     | Compile Error  | Infinite Loop   |
-| Effect Type Safety    | Complete       | Partial         |
+```osprey
+effect Exception { raise: fn(string) -> unit }
+effect State     { get: fn() -> int, set: fn(int) -> unit }
 
-### Static Analysis
+fn doubleAndStore(x: int) -> int ![Exception, State] = match x * 2 {
+    Success { value }   => {
+        perform State.set(value)
+        value
+    }
+    Error   { message } => {
+        perform Exception.raise(message)
+        0
+    }
+}
 
-The compiler performs static call graph analysis:
-
-1. Effect dependency graphs map which effects depend on others
-2. Handler call chains trace execution paths
-3. Cycle detection uses topological sorting
-4. Recursion analysis detects handlers calling functions that perform the same effect
-
-This ensures no effect-related runtime errors are possible.
-
-[1]: https://www.ospreylang.dev/spec/ "Osprey Language Specification - Osprey Programming Language"
-
-https://arxiv.org/pdf/1312.1399
-
-https://arxiv.org/pdf/1807.05923
-
-https://www.inner-product.com/posts/direct-style-effects/
-
-https://www.eff-lang.org/handlers-tutorial.pdf
-
-https://en.wikipedia.org/wiki/Effect_system
-
-https://dl.acm.org/doi/pdf/10.1145/3290319
-
-
-## Implementation Status
-
-Analysis of Osprey's implementation against Plotkin & Pretnar's algebraic effects theory:
-
-## Correctly Implemented
-
-### Effect Declarations
-- **Paper**: `op : α → β` (operation signatures)
-- **Osprey**: `effect EffectName { operationName: fn(α) -> β }`
-- **Status**: Correct mapping to paper's operation signatures
-
-### Perform Expressions
-- **Paper**: `opV(x : β. M)` (operation with continuation)
-- **Osprey**: `perform EffectName.operationName(args)`
-- **Status**: Correct - implicit continuation handling matches theory
-
-### Handler Syntax
-- **Paper**: `{opx : α(k : β → C) → Mop}`
-- **Osprey**: `handle EffectName operationName params => body in expr`
-- **Status**: Correct syntax mapping to theoretical foundation
-
-### Compile-Time Safety
-- **Paper**: Theoretical foundation only
-- **Osprey**: Compile-time unhandled effect detection
-- **Status**: Exceeds paper - goes beyond theory with compile-time verification
-
-### Effect Type System
-- **Paper**: Effect annotations and inference
-- **Osprey**: `fn name() -> Type !Effect` syntax
-- **Status**: Correct effect type annotations
-
-### Nested Handlers
-- **Paper**: Handler composition and nesting
-- **Osprey**: Multiple nested `handle...in` expressions
-- **Status**: Correct lexical scoping
-
-## Missing Features
-
-### Continuation/Resume Operations
-- **Paper**: Handlers have `k : β → C` continuations, explicit `resume(value)`
-- **Osprey**: **MISSING** - No `resume` operations implemented
-- **Impact**: **MAJOR** - This is fundamental to algebraic effects theory
-- **Status**: Documented as "COMING SOON" in README
-
-### Handler Semantics
-- **Paper**: Handlers must handle the continuation explicitly
-- **Osprey**: Current handlers use simple value substitutions
-- **Status**: Not fully implementing true algebraic effects without continuations
-
-### CPS Transformation
-- **Paper**: Requires continuation-passing style transformation
-- **Osprey**: Infrastructure exists but incomplete
-- **Status**: Cannot properly suspend/resume computation
-
-## Partially Implemented
-
-### Handler Execution
-- Parsing works, but execution is incomplete
-- No proper continuation capture/restoration
-- Multiple examples in `failscompilation/` directory
-
-### Multi-Effect Composition
-- `![Effect1, Effect2]` syntax exists
-- Complex interaction semantics not fully implemented
-
-## Osprey's Innovations
-
-### Compile-Time Effect Safety
-- 100% compile-time unhandled effect detection
-- Other languages crash at runtime; Osprey prevents compilation
-- Comprehensive test suite in `failscompilation/`
-
-### Circular Dependency Detection
-- Static analysis prevents infinite handler recursion
-- Detects circular effect dependencies at compile time
-
-### Fiber Integration
-- Effects system integrated with lightweight fibers
-- Type-safe concurrency with effect tracking
-
-## Overall Assessment
-
-| Aspect                    | Paper Requirement | Osprey Status | Assessment |
-| ------------------------- | ----------------- | ------------- | ---------- |
-| Effect Declarations       | Required          | Complete      | Correct    |
-| Perform Operations        | Required          | Complete      | Correct    |
-| Handler Syntax            | Required          | Complete      | Correct    |
-| Continuations/Resume      | Critical          | Missing       | Gap        |
-| Handler Semantics         | Critical          | Incomplete    | Gap        |
-| CPS Transformation        | Required          | Partial       | Gap        |
-| Compile-Time Safety       | Not specified     | Complete      | Innovation |
-| Effect Type System        | Required          | Complete      | Correct    |
-
-## Summary
-
-**Strengths:**
-- Correct syntax mapping to Plotkin & Pretnar theory
-- Compile-time safety exceeds theoretical requirements
-- Strong type system integration
-- Comprehensive test coverage for implemented features
-
-**Gaps:**
-- Missing continuation/resume operations (fundamental to algebraic effects)
-- Incomplete handler semantics (not full algebraic effects without continuations)
-- CPS transformation incomplete (cannot properly suspend/resume)
-
-**Innovations:**
-- Complete compile-time effect safety
-- Circular dependency detection
-- Fiber integration with effects
-
-Osprey provides approximately 80% theoretical correctness with practical innovations that surpass other implementations in safety guarantees. Full algebraic effects support requires implementing `resume(value)` operations in handlers for proper continuation-based semantics.
+handle Exception
+    raise msg => { print("error: " + msg); -1 }
+in
+    handle State
+        get        => 0
+        set newVal => print("state: " + toString(newVal))
+    in
+        let result = doubleAndStore(21)
+        print("result: " + toString(result))
+```


### PR DESCRIPTION
## TLDR
Trims ~3,100 net lines of aspirational prose, duplicated grammar, hand-written TOCs, and per-function tutorial pages from the 17 compiler spec chapters, leaving tighter canonical EBNF and minimal examples.

## Details
17 files in `compiler/spec/` touched (832 insertions, 3939 deletions).

- **Removed bloat**: marketing/design-principle bullets, citations (Plotkin & Pretnar), emoji status banners, hand-numbered TOCs in `0014-HTTP.md` and `0015-WebSockets.md`, per-function H4 prose pages collapsed to signature lists, 34 `**Examples:**` labels.
- **Deduplicated cross-chapter content**: Block Expressions removed from `0003-Syntax.md` (lives in `0008-BlockExpressions.md`), arithmetic-Result semantics removed from `0002-LexicalStructure.md` (lives in `0013-ErrorHandling.md`), Result auto-unwrap walkthrough removed from `0004-TypeSystem.md`.
- **Consolidated grammar**: `0003-Syntax.md` had duplicate `binary_expression` and `primary_expression` rules — merged into single EBNF blocks. Token-name notation (`LPAREN`, `COLON`, `ARROW`) replaced with quoted literal terminals (`"("`, `":"`, `"->"`).
- **Type-name normalization**: `Int`/`String`/`Bool`/`Unit` → `int`/`string`/`bool`/`unit`; `T -> U` lambda type syntax → `fn(T) -> U`.
- **Status sections**: new short `## Status` paragraphs in `0011`, `0014`, `0015`, `0016`, `0017` replace the tri-section "Correctly Implemented / Missing / Partially Implemented" implementation-status audits.
- **Heading rename pass**: `Lightweight Fibers and Concurrency` → `Fibers and Concurrency`; `Loop Constructs and Functional Iterators` → `Iterators and Iteration`; `Record Types and Type Constructors` → `Records`; `Hindley-Milner Type Inference` → `Hindley-Milner Inference`; etc.
- **Biggest cuts**: `0004-TypeSystem.md` (-898), `0014-HTTP.md` (-427), `0015-WebSockets.md` (-284), `0011-Lightweight...md` (-305), `0017-AlgebraicEffects.md` (-127).

No code, grammar file, or test changes. Documentation-only.

## How Do The Automated Tests Prove It Works?
`make ci` passes end-to-end on this branch:
- `golangci-lint run` → `0 issues`
- C runtime built with `-Werror -Wall -Wextra -Wpedantic` — no warnings
- vscode-extension test suite: 15 passing (26s), coverage 51.96% ≥ 51% threshold (`[vscode-extension] OK: 51.96% >= 51%`)
- Compiler binary and Rust interop library build cleanly

These prove the spec-only changes did not regress the compiler, runtime, or extension. Since the diff is markdown-only, there are no behavioral tests to add.