### PR TITLE
fix(round2): inline lambdas in iterators + Unit-return discard

### DIFF
--- a/compiler/internal/codegen/function_signatures.go
+++ b/compiler/internal/codegen/function_signatures.go
@@ -985,6 +985,13 @@ func (g *LLVMGenerator) maybeUnwrapResult(bodyValue value.Value, fnDecl *ast.Fun
 
 // canImplicitlyConvert checks if we can implicitly convert from one type to another
 func (g *LLVMGenerator) canImplicitlyConvert(fromType, toType Type, _ *ast.FunctionDeclaration) bool {
+	// Any body type can flow into a Unit-typed return slot — the value is
+	// simply discarded. This is what users mean when they write a side-effect
+	// `main() -> Unit = { xs |> forEachList(print) }` whose final expression
+	// happens to evaluate to a List.
+	if toConcrete, ok := toType.(*ConcreteType); ok && toConcrete.name == TypeUnit {
+		return true
+	}
 	// Handle the case where Result types are still ConcreteType due to type inference issues
 	if fromConcrete, ok := fromType.(*ConcreteType); ok {
 		if toConcrete, ok := toType.(*ConcreteType); ok {

--- a/compiler/internal/codegen/iterator_generation.go
+++ b/compiler/internal/codegen/iterator_generation.go
@@ -11,6 +11,48 @@ import (
 	"github.com/llir/llvm/ir/value"
 )
 
+// resolveCallbackIdent normalises an iterator callback argument into a
+// named-function identifier the loop generators can call back into.
+//
+//   - *ast.Identifier  → used as-is (the existing path).
+//   - *ast.LambdaExpression → emitted as a fresh top-level function and
+//     synthesised as an Identifier pointing at the generated name, so
+//     `forEach(xs, fn(x) => print(x))` works alongside the named-fn form.
+//   - anything else → returns notFnErr (the original "callback is not a
+//     function" rejection).
+func (g *LLVMGenerator) resolveCallbackIdent(
+	funcArg ast.Expression,
+	notFnErr error,
+) (*ast.Identifier, error) {
+	switch v := funcArg.(type) {
+	case *ast.Identifier:
+		return v, nil
+	case *ast.LambdaExpression:
+		// Run the inferer first so the lambda body's identifiers (including
+		// parameters) resolve once the codegen path below kicks in.
+		_, err := g.typeInferer.InferType(v)
+		if err != nil {
+			return nil, err
+		}
+		lambdaValue, err := g.generateLambdaExpression(v)
+		if err != nil {
+			return nil, err
+		}
+		lambdaFunc, ok := lambdaValue.(*ir.Func)
+		if !ok {
+			return nil, notFnErr
+		}
+		// Register under the generated mangled name so the existing
+		// callFunctionWithValue / monomorphisation paths can resolve it.
+		if g.functions == nil {
+			g.functions = make(map[string]*ir.Func)
+		}
+		g.functions[lambdaFunc.Name()] = lambdaFunc
+		return &ast.Identifier{Name: lambdaFunc.Name()}, nil
+	}
+	return nil, notFnErr
+}
+
 // generateRangeCall handles range function calls - creates an iterator from start to end.
 func (g *LLVMGenerator) generateRangeCall(callExpr *ast.CallExpression) (value.Value, error) {
 	err := validateBuiltInArgs(RangeFunc, callExpr)
@@ -61,9 +103,9 @@ func (g *LLVMGenerator) generateForEachCall(callExpr *ast.CallExpression) (value
 	// Get the function to apply from second argument
 	funcArg := callExpr.Arguments[1]
 
-	funcIdent, ok := funcArg.(*ast.Identifier)
-	if !ok {
-		return nil, ErrForEachNotFunction
+	funcIdent, err := g.resolveCallbackIdent(funcArg, ErrForEachNotFunction)
+	if err != nil {
+		return nil, err
 	}
 
 	// Extract range bounds
@@ -232,9 +274,9 @@ func (g *LLVMGenerator) generateMapCall(callExpr *ast.CallExpression) (value.Val
 	// Get the transformation function
 	funcArg := callExpr.Arguments[1]
 
-	funcIdent, ok := funcArg.(*ast.Identifier)
-	if !ok {
-		return nil, ErrMapNotFunction
+	funcIdent, err := g.resolveCallbackIdent(funcArg, ErrMapNotFunction)
+	if err != nil {
+		return nil, err
 	}
 
 	// STREAM FUSION: Store the map function for later fusion with forEach/fold
@@ -261,9 +303,9 @@ func (g *LLVMGenerator) generateFilterCall(callExpr *ast.CallExpression) (value.
 	// Get the predicate function
 	funcArg := callExpr.Arguments[1]
 
-	funcIdent, ok := funcArg.(*ast.Identifier)
-	if !ok {
-		return nil, ErrFilterNotFunction
+	funcIdent, err := g.resolveCallbackIdent(funcArg, ErrFilterNotFunction)
+	if err != nil {
+		return nil, err
 	}
 
 	// STREAM FUSION: Store the filter predicate for later fusion with forEach/fold
@@ -293,9 +335,9 @@ func (g *LLVMGenerator) generateFoldCall(callExpr *ast.CallExpression) (value.Va
 	// Get the fold function
 	funcArg := callExpr.Arguments[2]
 
-	funcIdent, ok := funcArg.(*ast.Identifier)
-	if !ok {
-		return nil, ErrFoldNotFunction
+	funcIdent, err := g.resolveCallbackIdent(funcArg, ErrFoldNotFunction)
+	if err != nil {
+		return nil, err
 	}
 
 	// Extract range bounds


### PR DESCRIPTION
## Summary

Two related bugfixes that combine to let the obvious functional-pipeline pattern compile:

```osprey
fn main() -> Unit = {
    range(1, 5) |> map(fn(x: int) => x * 10) |> forEach(print)
}
```

Previously failed with two separate errors.

## Changes

**1. Inline lambdas in iterator builtins (`iterator_generation.go`)**

`forEach` / `map` / `filter` / `fold` rejected anything that wasn't `*ast.Identifier` with \"callback is not a function\". New `resolveCallbackIdent` helper:

- `*ast.Identifier` passes through unchanged.
- `*ast.LambdaExpression` runs the inferer, emits the lambda via `generateLambdaExpression`, registers the resulting `*ir.Func` in `g.functions`, and returns a synthesised `Identifier` pointing at the generated name.

**2. Unit-return discard (`function_signatures.go`)**

`canImplicitlyConvert` now treats a Unit return type as accepting any body type. Without this, `fn main() -> Unit = { xs |> forEachList(print) }` failed with `Unit != List` because `forEachList` returns the list it iterated over.

## Test plan
- [x] `range(1, 5) |> map(fn(x:int) => x*10) |> forEach(print)` prints 10/20/30/40
- [x] `listAppend(...) |> forEachList(print)` in Unit-return main no longer rejects
- [x] Full `go test ./...` suite green
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)