### PR TITLE
chore(makefile): clean test.log alongside other build artefacts

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -157,6 +157,7 @@ clean:
 	rm -rf lib/
 	rm -rf outputs/
 	rm -rf internal/codegen/bin
+	rm -f test.log
 	find /tmp -name "*osprey*" -delete 2>/dev/null || true
 	find /tmp -name "*TestHTTP*" -delete 2>/dev/null || true
 	find /tmp -name "*TestManual*" -delete 2>/dev/null || true


### PR DESCRIPTION
Drop test.log in `make clean` so a clean build slate actually is one. Tiny cleanup follow-up to #56 / PR#71.