### PR TITLE
fix(codegen): list literal with record/union elements panic-to-error

### DIFF
--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -381,6 +381,11 @@ func (g *LLVMGenerator) generatePrintCall(callExpr *ast.CallExpression) (value.V
 
 // convertValueToStringForPrint converts any value to a string for printing.
 func (g *LLVMGenerator) convertValueToStringForPrint(arg value.Value, inferredType Type) (value.Value, error) {
+	// Unit-returning calls (print, …) hand back nil. Reject up-front rather
+	// than dereferencing nil downstream in convertPrimitiveToString.
+	if arg == nil {
+		return nil, ErrPrintOnUnit
+	}
 	if g.isResultType(arg) {
 		return g.convertResultValueToString(arg)
 	}

--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -37,6 +37,13 @@ func (g *LLVMGenerator) generateToStringCall(callExpr *ast.CallExpression) (valu
 		return nil, err
 	}
 
+	// Unit-returning calls (print, …) hand back nil. Reject toString of
+	// such values up-front with a clear error rather than crashing the
+	// compiler in downstream type checks (was: nil-deref in isResultType).
+	if arg == nil {
+		return nil, ErrToStringOnUnit
+	}
+
 	// TODO: check if result type. The value should have type info attached to it
 	// If not, something has gone wrong
 	if g.isResultType(arg) {

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -81,6 +81,10 @@ var (
 	ErrUndefinedVariable        = errors.New("undefined variable")
 	ErrUnsupportedBinaryOp      = errors.New("unsupported binary operator") // Alias for ErrUnsupportedBinaryOperator
 	ErrStructComparisonNotImpl  = errors.New("structural comparison on records/unions is not yet implemented")
+	ErrListLiteralAggregateElem = errors.New(
+		"list literals with record/union elements are not yet supported; " +
+			"use listAppend(List(), record) to build the list element-by-element",
+	)
 
 	ErrMethodNotImpl         = errors.New("method not implemented")
 	ErrNoToStringForFunc     = errors.New("no toString implementation for function")

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -63,6 +63,7 @@ var (
 	ErrPrintCannotConvert = errors.New("cannot convert value for printing")
 	ErrUnsupportedCall    = errors.New("unsupported function call")
 	ErrToStringReserved   = errors.New("toString is a reserved function name")
+	ErrToStringOnUnit     = errors.New("toString does not accept a Unit-returning expression (e.g. print)")
 
 	ErrWebSocketKeepAliveWrongArgs = errors.New("websocketKeepAlive function has wrong number of arguments")
 

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrUnsupportedCall    = errors.New("unsupported function call")
 	ErrToStringReserved   = errors.New("toString is a reserved function name")
 	ErrToStringOnUnit     = errors.New("toString does not accept a Unit-returning expression (e.g. print)")
+	ErrPrintOnUnit        = errors.New("print does not accept a Unit-typed value (e.g. the result of another print)")
 
 	ErrWebSocketKeepAliveWrongArgs = errors.New("websocketKeepAlive function has wrong number of arguments")
 

--- a/compiler/internal/codegen/expression_generation.go
+++ b/compiler/internal/codegen/expression_generation.go
@@ -250,6 +250,14 @@ func (g *LLVMGenerator) generateListLiteral(lit *ast.ListLiteral) (value.Value, 
 		// For maps, element type is a pointer to the map struct type
 		elementType = types.NewPointer(types.NewStruct(types.I64, types.I8Ptr))
 		elementSize = 8 // pointer size
+	case *ast.TypeConstructorExpression:
+		// Record / union-variant literals lower to multi-field structs that
+		// don't fit the i64-or-pointer assumption below. The store at line
+		// ~281 would crash with "store operands are not compatible: src={...};
+		// dst=i64*". Treat aggregate-element lists as not-yet-supported with
+		// a clear error rather than a runtime panic.
+		return nil, fmt.Errorf("list literals with record/union elements " +
+			"are not yet supported; use listAppend(List(), record) to build the list element-by-element")
 	default:
 		elementType = types.I64
 		elementSize = 8 // i64 size

--- a/compiler/internal/codegen/expression_generation.go
+++ b/compiler/internal/codegen/expression_generation.go
@@ -256,8 +256,7 @@ func (g *LLVMGenerator) generateListLiteral(lit *ast.ListLiteral) (value.Value, 
 		// ~281 would crash with "store operands are not compatible: src={...};
 		// dst=i64*". Treat aggregate-element lists as not-yet-supported with
 		// a clear error rather than a runtime panic.
-		return nil, fmt.Errorf("list literals with record/union elements " +
-			"are not yet supported; use listAppend(List(), record) to build the list element-by-element")
+		return nil, ErrListLiteralAggregateElem
 	default:
 		elementType = types.I64
 		elementSize = 8 // i64 size

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -1159,6 +1159,12 @@ func (g *LLVMGenerator) wrapInSuccessResult(discriminant value.Value) value.Valu
 
 // isResultType checks if a value is a Result type (struct with two fields or pointer to such struct)
 func (g *LLVMGenerator) isResultType(val value.Value) bool {
+	// Unit-returning builtins (e.g. print) hand back a nil value; treat as
+	// not-a-Result so callers like toString can fail loud instead of
+	// crashing the compiler dereferencing a nil interface.
+	if val == nil {
+		return false
+	}
 	// Check for pointer to struct (legacy pointer semantics)
 	if ptrType, ok := val.Type().(*types.PointerType); ok {
 		if structType, ok := ptrType.ElemType.(*types.StructType); ok {


### PR DESCRIPTION
## Summary

\`[Box{x:1}, Box{x:2}]\` crashed the compiler with:
\`\`\`
panic: store operands are not compatible: src={ i8*, i64 }; dst=i64*
\`\`\`

\`generateListLiteral\` picks the element LLVM type by switching on the first element's AST node. Record/union literals (\`TypeConstructorExpression\`) fell through to the default i64 branch; then \`NewStore\` tried to fit a multi-field struct into an i64 slot and llir blew up.

Aggregate elements in list literals are a real feature gap (the list cell needs to be sized for the struct, and \`forEachList\` needs to know how to read them). This commit intercepts the case up-front with a clear error that points users at the working \`listAppend(List(), record)\` build pattern.

## Test plan
- [x] \`[Box{...}, Box{...}]\` now reports \"list literals with record/union elements are not yet supported; use listAppend(List(), record) to build the list element-by-element\"
- [x] \`go test ./...\` green
- [x] \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)