### PR TITLE
fix(codegen): reuse existing module function for extern declarations

### DIFF
--- a/compiler/internal/codegen/statement_generation.go
+++ b/compiler/internal/codegen/statement_generation.go
@@ -65,13 +65,11 @@ func (g *LLVMGenerator) generateExternDeclaration(externDecl *ast.ExternDeclarat
 
 	// Declare the external function. If the compiler has already emitted a
 	// declaration with the same name (e.g. strlen / printf / malloc — used
-	// internally for built-in lowering), reuse it instead of emitting a
-	// duplicate "declare" line that llc rejects with
+	// internally for built-in lowering), keep that declaration instead of
+	// emitting a duplicate "declare" line that llc rejects with
 	// "invalid redefinition of function".
-	externFunc, exists := g.functions[externDecl.Name]
-	if !exists {
-		externFunc = g.module.NewFunc(externDecl.Name, returnType, params...)
-		g.functions[externDecl.Name] = externFunc
+	if _, exists := g.functions[externDecl.Name]; !exists {
+		g.functions[externDecl.Name] = g.module.NewFunc(externDecl.Name, returnType, params...)
 	}
 	// Built-in functions are handled by Hindley-Milner type inference
 	g.functionParameters[externDecl.Name] = paramNames

--- a/compiler/internal/codegen/statement_generation.go
+++ b/compiler/internal/codegen/statement_generation.go
@@ -63,9 +63,16 @@ func (g *LLVMGenerator) generateExternDeclaration(externDecl *ast.ExternDeclarat
 		returnType = g.typeExpressionToLLVMType(externDecl.ReturnType)
 	}
 
-	// Declare the external function
-	externFunc := g.module.NewFunc(externDecl.Name, returnType, params...)
-	g.functions[externDecl.Name] = externFunc
+	// Declare the external function. If the compiler has already emitted a
+	// declaration with the same name (e.g. strlen / printf / malloc — used
+	// internally for built-in lowering), reuse it instead of emitting a
+	// duplicate "declare" line that llc rejects with
+	// "invalid redefinition of function".
+	externFunc, exists := g.functions[externDecl.Name]
+	if !exists {
+		externFunc = g.module.NewFunc(externDecl.Name, returnType, params...)
+		g.functions[externDecl.Name] = externFunc
+	}
 	// Built-in functions are handled by Hindley-Milner type inference
 	g.functionParameters[externDecl.Name] = paramNames
 


### PR DESCRIPTION
## Summary

\`extern fn strlen(s: string) -> int\` made llc reject the IR with:
\`\`\`
invalid redefinition of function 'strlen'
declare i64 @strlen(i8* %s)
\`\`\`
because the compiler already declares strlen / printf / malloc / scanf / strcmp / strstr / memcpy internally, and \`generateExternDeclaration\` unconditionally re-declared on every extern.

Fix: when \`g.functions[name]\` is already populated, reuse that \`*ir.Func\` instead of emitting a second \`declare\`. The type-environment registration runs in either branch so the inferer still sees the user's declared signature.

## Test plan
- [x] \`extern fn strlen(s: string) -> int\` + \`strlen(\"hello world\")\` compiles and returns 11
- [x] \`go test ./...\` green
- [x] \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)