### PR TITLE
fix(codegen): allow spawn of Unit-returning functions

### DIFF
--- a/compiler/internal/codegen/effects_generation.go
+++ b/compiler/internal/codegen/effects_generation.go
@@ -424,7 +424,8 @@ func (ec *EffectCodegen) createHandlerFunction(
 }
 
 // hasDeclaredEffect checks if the current function declares the given effect
-// TODO: This will be used for proper effect forwarding in the future
+// in its `!Effect` list; used by performExpression to allow forwarding a
+// perform up the call chain without an immediate handler.
 func (ec *EffectCodegen) hasDeclaredEffect(effectName string) bool {
 	if ec.currentFunctionEffects == nil {
 		return false
@@ -578,8 +579,9 @@ func (ec *EffectCodegen) generatePerformArguments(perform *ast.PerformExpression
 	return args, nil
 }
 
-// createUnhandledEffectError creates a proper error for unhandled effects
-// TODO: This will be used for proper compile-time effect checking in the future
+// createUnhandledEffectError creates a position-aware compile error for
+// performExpressions that have no live handler. Includes a special-case
+// hint when the chain looks like circular effect dependency.
 func (ec *EffectCodegen) createUnhandledEffectError(perform *ast.PerformExpression) error {
 	// Check if this is potentially a circular dependency scenario
 	if ec.isLikelyCircularDependency(perform.EffectName) {

--- a/compiler/internal/codegen/fiber_generation.go
+++ b/compiler/internal/codegen/fiber_generation.go
@@ -151,15 +151,28 @@ func (g *LLVMGenerator) generateSpawnExpression(spawn *ast.SpawnExpression) (val
 	if err != nil {
 		return nil, err
 	}
-	// AUTO-UNWRAP Result types for fiber operations per spec (0004-TypeSystem.md:115-160)
-	result = g.unwrapIfResult(result)
+	// Unit-returning spawn bodies (e.g. `spawn doit()` where doit returns
+	// Unit via print) leave us with a nil or void-typed value. The fiber
+	// closure signature is `i64()` so a `ret void` would fail llc with
+	// "value doesn't match function result type 'i64'". Return a zero
+	// placeholder for Unit so the fiber's await result is 0 / discardable.
+	var resultForRuntime value.Value
+	switch {
+	case result == nil:
+		resultForRuntime = constant.NewInt(types.I64, 0)
+	case result.Type().Equal(types.Void):
+		resultForRuntime = constant.NewInt(types.I64, 0)
+	default:
+		// AUTO-UNWRAP Result types for fiber operations per spec (0004-TypeSystem.md:115-160)
+		result = g.unwrapIfResult(result)
 
-	// Convert the result to i64 for the fiber runtime if needed
-	// The fiber runtime always expects i64, so we need to convert other types
-	resultForRuntime := result
-	if floatType, ok := result.Type().(*types.FloatType); ok && floatType == types.Double {
-		// Convert double to i64 using bitcast to preserve the bits
-		resultForRuntime = g.builder.NewBitCast(result, types.I64)
+		// Convert the result to i64 for the fiber runtime if needed
+		// The fiber runtime always expects i64, so we need to convert other types
+		resultForRuntime = result
+		if floatType, ok := result.Type().(*types.FloatType); ok && floatType == types.Double {
+			// Convert double to i64 using bitcast to preserve the bits
+			resultForRuntime = g.builder.NewBitCast(result, types.I64)
+		}
 	}
 
 	// Return the result


### PR DESCRIPTION
## Summary
\`spawn doit()\` where doit returns Unit produced invalid IR:

\`\`\`llvm
define i64 @fiber_closure_1() {
entry:
    call void @doit()
    ret void %0     ; llc: value doesn't match function result type 'i64'
}
\`\`\`

Returns an \`i64 0\` placeholder for nil or void-typed spawn bodies; non-Unit bodies are unchanged. The fiber's await result for a Unit body is now a discardable 0.

## Test plan
- [x] \`spawn doit()\` where doit returns Unit now compiles and runs
- [x] Existing fiber tests still pass
- [x] make lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)