### PR TITLE
fix(errors): named-arg unknown-param message lists the valid parameters

### DIFF
--- a/compiler/internal/codegen/match_validation.go
+++ b/compiler/internal/codegen/match_validation.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/christianfindlay/osprey/internal/ast"
 )
@@ -203,7 +204,8 @@ func (g *LLVMGenerator) reorderNamedArguments(fnName string, args []ast.NamedArg
 	for _, arg := range args {
 		pos, exists := paramPositions[arg.Name]
 		if !exists {
-			return nil, fmt.Errorf("%w: %s", ErrUnknownParameterName, arg.Name)
+			return nil, fmt.Errorf("%w '%s' for function '%s'; valid parameters: %s",
+				ErrUnknownParameterName, arg.Name, fnName, strings.Join(paramNames, ", "))
 		}
 
 		reorderedArgs[pos] = arg.Value


### PR DESCRIPTION
`sumPair(x: 5, y: 7)` against `fn sumPair(a, b)` produced bare `unknown parameter name: x`. Now: `unknown parameter name 'x' for function 'sumPair'; valid parameters: a, b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)