### PR TITLE
fix(codegen): auto-unwrap Result-shaped field values in record constructor

### DIFF
--- a/compiler/internal/codegen/expression_generation.go
+++ b/compiler/internal/codegen/expression_generation.go
@@ -1944,6 +1944,14 @@ func (g *LLVMGenerator) generateRecordField(
 		return nil, nil, err
 	}
 
+	// Auto-unwrap Result-typed field values into the declared primitive
+	// field slot — `Pt { x: p.x + dx }` produces Result<int, MathError>
+	// even though field x is declared i64. Without this the struct ends up
+	// nested {{i64,i8}, ...} and llc rejects.
+	if declaredLLVMType != nil && declaredLLVMType != fieldValue.Type() && g.isResultType(fieldValue) {
+		fieldValue = g.unwrapIfResult(fieldValue)
+	}
+
 	// Use actual field value type for polymorphic records
 	return fieldValue, fieldValue.Type(), nil
 }

--- a/compiler/internal/codegen/match_validation.go
+++ b/compiler/internal/codegen/match_validation.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/christianfindlay/osprey/internal/ast"
 )
@@ -203,7 +204,8 @@ func (g *LLVMGenerator) reorderNamedArguments(fnName string, args []ast.NamedArg
 	for _, arg := range args {
 		pos, exists := paramPositions[arg.Name]
 		if !exists {
-			return nil, fmt.Errorf("%w: %s", ErrUnknownParameterName, arg.Name)
+			return nil, fmt.Errorf("%w '%s' for function '%s'; valid parameters: %s",
+				ErrUnknownParameterName, arg.Name, fnName, strings.Join(paramNames, ", "))
 		}
 
 		reorderedArgs[pos] = arg.Value

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -2516,8 +2516,17 @@ func (ti *TypeInferer) inferAndUnifyRecordFields(
 			if ct, ok := expectedFieldType.(*ConcreteType); !ok || isKnownConcreteType(ct.name) {
 				err := ti.Unify(fieldType, expectedFieldType)
 				if err != nil {
-					return nil, fmt.Errorf("field %s type mismatch in %s constructor: %w",
-						fieldName, recordType.name, err)
+					// Spec auto-unwrap: a Result<T,E> field value flows into
+					// a T-typed field slot (e.g. `Pt { x: p.x + dx }` where
+					// `+` produces Result<int, MathError>). Retry unification
+					// with the inferred field type unwrapped.
+					unwrappedFieldType := ti.unwrapResultType(fieldType)
+					retryErr := ti.Unify(unwrappedFieldType, expectedFieldType)
+					if retryErr != nil {
+						return nil, fmt.Errorf("field %s type mismatch in %s constructor: %w",
+							fieldName, recordType.name, err)
+					}
+					fieldType = unwrappedFieldType
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

\`shift(p, dx, dy) = Pt { x: p.x + dx, y: p.y + dy }\` failed:
- first at inference: \`field x type mismatch in Pt constructor: Result<int, MathError> != int\`
- then at llc: \`value doesn't match function result type '{ i64, i64 }'\` because the struct came out \`{{i64,i8}, {i64,i8}}\`.

## Fix

Two coordinated changes:

1. **type_inference.go** \`inferRecordType\`: retry unification with the field's inferred type unwrapped (Result<T,E> → T) before declaring a mismatch.
2. **expression_generation.go** \`generateRecordField\`: when the declared field LLVM type is a primitive and the generated value is a Result struct, unwrap the value before storing.

## Test plan
- [x] \`Pt { x: p.x + dx, y: p.y + dy }\` compiles and produces correct values
- [x] Primitive-into-primitive flows unchanged
- [x] \`go test ./...\` green
- [x] \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)