### PR TITLE
fix(match): float-literal patterns are now recognised everywhere

### DIFF
--- a/compiler/internal/ast/builder_match.go
+++ b/compiler/internal/ast/builder_match.go
@@ -114,6 +114,16 @@ func (b *Builder) tryBuildNegativeNumberPattern(pipeCtx parser.IPipeExprContext)
 						IsWildcard:  false,
 					}
 				}
+				// Negative float literal — same shape on FLOAT.
+				if literalCtx.FLOAT() != nil {
+					return Pattern{
+						Constructor: "-" + literalCtx.FLOAT().GetText(),
+						Variable:    "",
+						Fields:      nil,
+						Nested:      nil,
+						IsWildcard:  false,
+					}
+				}
 			}
 		}
 	}

--- a/compiler/internal/ast/builder_match.go
+++ b/compiler/internal/ast/builder_match.go
@@ -180,6 +180,17 @@ func (b *Builder) buildLiteralPattern(literalCtx parser.ILiteralContext) Pattern
 			Nested:      nil,
 			IsWildcard:  false,
 		}
+	} else if literalCtx.FLOAT() != nil {
+		// `match f { 3.14 => … }` previously fell through and produced
+		// 'unknown constructor: unknown'. Capture the float text so
+		// match codegen + inferer can recognise it as a literal.
+		return Pattern{
+			Constructor: literalCtx.FLOAT().GetText(),
+			Variable:    "",
+			Fields:      nil,
+			Nested:      nil,
+			IsWildcard:  false,
+		}
 	}
 
 	return Pattern{Constructor: unknownPatternConstructor}

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -1606,10 +1606,15 @@ func (g *LLVMGenerator) createPatternCondition(
 		return g.createUnionPatternCondition(discriminantValue, discriminant, currentBlock)
 	}
 
-	// Handle numeric literals
+	// Handle numeric literals (int first — fastest path).
 	patternValue, err := strconv.ParseInt(pattern.Constructor, 10, 64)
 	if err == nil {
 		return g.createNumericPatternCondition(patternValue, discriminant, currentBlock)
+	}
+
+	// Float literal pattern — emit an FCmp against the literal constant.
+	if floatValue, ferr := strconv.ParseFloat(pattern.Constructor, 64); ferr == nil {
+		return currentBlock.NewFCmp(enum.FPredOEQ, discriminant, constant.NewFloat(types.Double, floatValue))
 	}
 
 	// Default to string pattern condition

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -1613,7 +1613,8 @@ func (g *LLVMGenerator) createPatternCondition(
 	}
 
 	// Float literal pattern — emit an FCmp against the literal constant.
-	if floatValue, ferr := strconv.ParseFloat(pattern.Constructor, 64); ferr == nil {
+	floatValue, ferr := strconv.ParseFloat(pattern.Constructor, 64)
+	if ferr == nil {
 		return currentBlock.NewFCmp(enum.FPredOEQ, discriminant, constant.NewFloat(types.Double, floatValue))
 	}
 

--- a/compiler/internal/codegen/match_validation.go
+++ b/compiler/internal/codegen/match_validation.go
@@ -268,13 +268,15 @@ func isLiteralPattern(constructor string) bool {
 	}
 
 	// Integer literals (try parsing)
-	if _, err := strconv.ParseInt(constructor, 10, 64); err == nil {
+	_, intErr := strconv.ParseInt(constructor, 10, 64)
+	if intErr == nil {
 		return true
 	}
 
 	// Float literals (e.g. `3.14`) — added so `match f { 3.14 => … }`
 	// passes the validator alongside int literals.
-	if _, err := strconv.ParseFloat(constructor, 64); err == nil {
+	_, floatErr := strconv.ParseFloat(constructor, 64)
+	if floatErr == nil {
 		return true
 	}
 

--- a/compiler/internal/codegen/match_validation.go
+++ b/compiler/internal/codegen/match_validation.go
@@ -268,8 +268,13 @@ func isLiteralPattern(constructor string) bool {
 	}
 
 	// Integer literals (try parsing)
-	_, err := strconv.ParseInt(constructor, 10, 64)
-	if err == nil {
+	if _, err := strconv.ParseInt(constructor, 10, 64); err == nil {
+		return true
+	}
+
+	// Float literals (e.g. `3.14`) — added so `match f { 3.14 => … }`
+	// passes the validator alongside int literals.
+	if _, err := strconv.ParseFloat(constructor, 64); err == nil {
 		return true
 	}
 

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -764,9 +764,15 @@ func (ti *TypeInferer) InferPatternWithType(pattern ast.Pattern, discriminantTyp
 		return &ConcreteType{name: TypeBool}, nil
 	default:
 		// Check if it's an integer literal pattern
-		_, err := strconv.ParseInt(pattern.Constructor, 10, 64)
-		if err == nil {
+		if _, err := strconv.ParseInt(pattern.Constructor, 10, 64); err == nil {
 			return &ConcreteType{name: TypeInt}, nil
+		}
+
+		// Check if it's a float literal pattern (e.g. `3.14`). Added so
+		// `match f { 3.14 => … }` infers as float instead of failing
+		// with "unknown constructor".
+		if _, err := strconv.ParseFloat(pattern.Constructor, 64); err == nil {
+			return &ConcreteType{name: TypeFloat}, nil
 		}
 
 		// Check if it's a string literal pattern (quoted)

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -764,14 +764,16 @@ func (ti *TypeInferer) InferPatternWithType(pattern ast.Pattern, discriminantTyp
 		return &ConcreteType{name: TypeBool}, nil
 	default:
 		// Check if it's an integer literal pattern
-		if _, err := strconv.ParseInt(pattern.Constructor, 10, 64); err == nil {
+		_, intErr := strconv.ParseInt(pattern.Constructor, 10, 64)
+		if intErr == nil {
 			return &ConcreteType{name: TypeInt}, nil
 		}
 
 		// Check if it's a float literal pattern (e.g. `3.14`). Added so
 		// `match f { 3.14 => … }` infers as float instead of failing
 		// with "unknown constructor".
-		if _, err := strconv.ParseFloat(pattern.Constructor, 64); err == nil {
+		_, floatErr := strconv.ParseFloat(pattern.Constructor, 64)
+		if floatErr == nil {
 			return &ConcreteType{name: TypeFloat}, nil
 		}
 


### PR DESCRIPTION
## Summary
`match f { 3.14 => … }` previously failed at one of three layers depending on path: AST 'unknown constructor: unknown', inferer 'unknown constructor: 3.14', or codegen silently treating the literal as a string pattern.

Fixes:
- builder_match.go: capture FLOAT() into Pattern.Constructor
- match_validation.go: isLiteralPattern accepts ParseFloat-valid text
- type_inference.go: float patterns infer as TypeFloat
- llvm.go: createPatternCondition emits FCmp(OEQ, discriminant, literal)

## Test plan
- [x] `match 3.14 { 3.14 => … }` runs
- [x] `fn classify(x: float) -> string = match x { 0.0 => 'zero'; _ => … }` works
- [x] All tests + lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)