### PR TITLE
fix(codegen): forEachList accepts inline lambdas via resolveCallbackIdent

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -397,10 +397,12 @@ func (g *LLVMGenerator) generateForEachListCall(callExpr *ast.CallExpression) (v
 	if err != nil {
 		return nil, err
 	}
+	// Accept either a named-fn identifier or an inline lambda (matches the
+	// resolveCallbackIdent helper used by forEach / map / filter / fold).
 	funcArg := callExpr.Arguments[1]
-	funcIdent, ok := funcArg.(*ast.Identifier)
-	if !ok {
-		return nil, errForEachListSecondArg
+	funcIdent, err := g.resolveCallbackIdent(funcArg, errForEachListSecondArg)
+	if err != nil {
+		return nil, err
 	}
 
 	// Use osprey_list_length + osprey_list_get for a simple counted loop.


### PR DESCRIPTION
## Summary

\`xs |> forEachList(fn(n: int) => print(toString(n)))\` rejected with:
\`\`\`
forEachList: second argument must be a function name
\`\`\`
because \`generateForEachListCall\` only accepted \`*ast.Identifier\`, while \`forEach\` / \`map\` / \`filter\` / \`fold\` already went through \`resolveCallbackIdent\` which emits an inline \`LambdaExpression\` as a fresh top-level function first.

## Fix

Route \`generateForEachListCall\` through the same helper. The named-fn path is unchanged.

## Test plan
- [x] \`xs |> forEachList(fn(n:int) => print(toString(n)))\` prints elements
- [x] Existing named-fn forEachList tests pass
- [x] \`go test ./...\` green
- [x] \`make lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)