### PR TITLE
fix(codegen): forEachList rejects list-literal arg with clean error instead of segfault

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -397,6 +397,17 @@ func (g *LLVMGenerator) generateForEachListCall(callExpr *ast.CallExpression) (v
 	if err != nil {
 		return nil, err
 	}
+	// List literals (`[1, 2, 3]`) lower to an inline `{i64, i8*}` struct
+	// on the stack, but forEachList expects an opaque `i8*` handle backed
+	// by the C runtime's OspreyList. Without this guard the runtime
+	// segfaults at osprey_list_length. Use listAppend(List(), …) instead
+	// for now until [TYPE-LIST-LITERAL] is rewired to the C runtime.
+	if list.Type() != types.I8Ptr {
+		return nil, fmt.Errorf("%w: forEachList currently requires a "+
+			"runtime-allocated list (built with List() / listAppend / split / ...). "+
+			"List literals like [1, 2, 3] aren't wired through the C list runtime yet",
+			errCollectionExternMiss)
+	}
 	// Accept either a named-fn identifier or an inline lambda (matches the
 	// resolveCallbackIdent helper used by forEach / map / filter / fold).
 	funcArg := callExpr.Arguments[1]

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -2255,11 +2255,12 @@ func (g *LLVMGenerator) generateSuccessBlock(
 		g.typeInferer.env = oldEnv
 	}()
 
-	// Find the success arm and bind pattern variables
+	// Find the success arm and bind pattern variables. Accept both
+	// destructure form `Success { value }` (Pattern.Fields) and
+	// variable-bind form `Success v` (Pattern.Variable); previously
+	// only Fields was honoured, so `Success v => v` reported v undefined.
 	successArm := g.findSuccessArm(matchExpr)
-	if successArm != nil && len(successArm.Pattern.Fields) > 0 {
-		// Bind the Result value to the pattern variable
-		fieldName := successArm.Pattern.Fields[0] // First field is the value
+	if fieldName := resultArmBindName(successArm); fieldName != "" {
 
 		// Bind the extracted value type to the pattern variable
 		g.bindPatternVariableType(fieldName, matchExpr.Expression)
@@ -2313,8 +2314,7 @@ func (g *LLVMGenerator) generateSuccessBlock(
 	}
 
 	// Fallback: use the bound variable from pattern matching
-	if successArm := g.findSuccessArm(matchExpr); successArm != nil && len(successArm.Pattern.Fields) > 0 {
-		fieldName := successArm.Pattern.Fields[0]
+	if fieldName := resultArmBindName(g.findSuccessArm(matchExpr)); fieldName != "" {
 		if extractedValue, exists := g.variables[fieldName]; exists {
 			successValue = extractedValue
 		} else {
@@ -2346,11 +2346,11 @@ func (g *LLVMGenerator) generateErrorBlock(
 		g.typeInferer.env = oldEnv
 	}()
 
-	// Find the Error arm and bind pattern variables
+	// Find the Error arm and bind pattern variables. Accept both
+	// destructure form `Error { message }` and variable-bind form
+	// `Error e`; previously only Fields was honoured.
 	errorArm := g.findErrorArm(matchExpr)
-	if errorArm != nil && len(errorArm.Pattern.Fields) > 0 {
-		// Bind the Result error message to the pattern variable
-		fieldName := errorArm.Pattern.Fields[0] // First field is the message
+	if fieldName := resultArmBindName(errorArm); fieldName != "" {
 
 		// Bind the error type to the pattern variable in the type environment
 		matchedExprType, err := g.typeInferer.InferType(matchExpr.Expression)
@@ -2413,8 +2413,7 @@ func (g *LLVMGenerator) generateErrorBlock(
 	}
 
 	// Fallback: use the bound variable from pattern matching
-	if errorArm := g.findErrorArm(matchExpr); errorArm != nil && len(errorArm.Pattern.Fields) > 0 {
-		fieldName := errorArm.Pattern.Fields[0]
+	if fieldName := resultArmBindName(g.findErrorArm(matchExpr)); fieldName != "" {
 		if extractedError, exists := g.variables[fieldName]; exists {
 			errorValue = extractedError
 		} else {
@@ -2470,6 +2469,21 @@ func (g *LLVMGenerator) bindPatternVariableType(fieldName string, matchedExpr as
 		// In this case, the success value type is the matched expression's type itself
 		g.typeInferer.env.Set(fieldName, resolvedType)
 	}
+}
+
+// resultArmBindName returns the binding name a Success/Error arm
+// introduces — either the first destructured field
+// (`Success { value }` → "value") or the constructor's variable bind
+// (`Success v` → "v"). Returns "" when the arm has neither (e.g.
+// `Success => 0`), so callers can skip binding.
+func resultArmBindName(arm *ast.MatchArm) string {
+	if arm == nil {
+		return ""
+	}
+	if len(arm.Pattern.Fields) > 0 {
+		return arm.Pattern.Fields[0]
+	}
+	return arm.Pattern.Variable
 }
 
 // findSuccessArm finds the success match arm.

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -853,21 +853,31 @@ func (ti *TypeInferer) handlePatternFieldBindings(pattern ast.Pattern, discrimin
 	}
 }
 
+// patternBindName returns the binding name a Success/Error arm
+// introduces — destructure form `Success { value }` (Fields[0]) or
+// variable-bind form `Success v` (Variable). Returns "" when neither
+// is present (e.g. `Success => 0`).
+func patternBindName(pattern ast.Pattern) string {
+	if len(pattern.Fields) > 0 {
+		return pattern.Fields[0]
+	}
+	return pattern.Variable
+}
+
 // bindSuccessPattern binds pattern fields for Success constructor
 func (ti *TypeInferer) bindSuccessPattern(pattern ast.Pattern, discriminantType Type) bool {
+	name := patternBindName(pattern)
 	// Handle GenericType Result<T, E>
 	if gt, ok := discriminantType.(*GenericType); ok && gt.name == TypeResult && len(gt.typeArgs) >= 1 {
-		successType := gt.typeArgs[0]
-		if len(pattern.Fields) > 0 {
-			ti.env.Set(pattern.Fields[0], successType)
+		if name != "" {
+			ti.env.Set(name, gt.typeArgs[0])
 		}
 		return true
 	}
 	// Handle ConcreteType Result<T, E> (legacy string-based approach)
 	if ct, ok := discriminantType.(*ConcreteType); ok && strings.HasPrefix(ct.name, "Result<") {
-		successType := ti.extractResultSuccessType(ct.name)
-		if len(pattern.Fields) > 0 {
-			ti.env.Set(pattern.Fields[0], successType)
+		if name != "" {
+			ti.env.Set(name, ti.extractResultSuccessType(ct.name))
 		}
 		return true
 	}
@@ -876,19 +886,18 @@ func (ti *TypeInferer) bindSuccessPattern(pattern ast.Pattern, discriminantType 
 
 // bindErrorPattern binds pattern fields for Error constructor
 func (ti *TypeInferer) bindErrorPattern(pattern ast.Pattern, discriminantType Type) bool {
+	name := patternBindName(pattern)
 	// Handle GenericType Result<T, E>
 	if gt, ok := discriminantType.(*GenericType); ok && gt.name == "Result" && len(gt.typeArgs) >= 2 {
-		errorType := gt.typeArgs[1]
-		if len(pattern.Fields) > 0 {
-			ti.env.Set(pattern.Fields[0], errorType)
+		if name != "" {
+			ti.env.Set(name, gt.typeArgs[1])
 		}
 		return true
 	}
 	// Handle ConcreteType Result<T, E> (legacy string-based approach)
 	if ct, ok := discriminantType.(*ConcreteType); ok && strings.HasPrefix(ct.name, "Result<") {
-		errorType := ti.extractResultErrorType(ct.name)
-		if len(pattern.Fields) > 0 {
-			ti.env.Set(pattern.Fields[0], errorType)
+		if name != "" {
+			ti.env.Set(name, ti.extractResultErrorType(ct.name))
 		}
 		return true
 	}


### PR DESCRIPTION
## Summary

Two fixes bundled together (both in single commit):

### forEachList list-literal rejection (Osprey1)
`[1, 2, 3] |> forEachList(print)` segfaulted at runtime — list literals lower to an inline `{i64, i8*}` stack struct, but `forEachList` calls `osprey_list_length` expecting an opaque `i8*` handle backed by the C runtime's `OspreyList` layout. Added an LLVM-type guard at the top of `generateForEachListCall`: non-`i8*` argument now surfaces a clear "list literals aren't wired through the C list runtime yet, use List() / listAppend instead" compile error.

### Result match variable-bind (Osprey2)
`match r { Success v => v; Error e => 0 }` reported `undefined variable 'v'`. The Success/Error pattern-binding paths (both inferer and codegen) only honoured the destructure form `Success { value }` (Pattern.Fields[0]), ignoring the variable-bind form `Success v` (Pattern.Variable). Extracted a `patternBindName` / `resultArmBindName` helper that returns whichever is present.

## Test plan
- [x] `[1, 2, 3] |> forEachList(print)` now reports a clean error instead of segfaulting
- [x] `listAppend(List(), 10) |> forEachList(print)` still works
- [x] `Success v => v` and `Error e => e` now compile and bind correctly
- [x] `make test` green; `make lint` clean