### PR TITLE
fix(cli): runtime-lib lookup prefers compiler-binary-relative paths

### DIFF
--- a/compiler/internal/codegen/compilation.go
+++ b/compiler/internal/codegen/compilation.go
@@ -119,8 +119,15 @@ func CompileToExecutable(source, outputPath string) error {
 	})
 }
 
-// buildLibraryPaths builds the search paths for runtime libraries
+// buildLibraryPaths builds the search paths for runtime libraries.
+// Compiler-binary-relative paths (binDir/bin and binDir/../lib) are
+// checked before the /usr/local/lib system install. Without this, a
+// freshly built osprey run from outside the repo resolves stale system
+// libs (missing new runtime symbols added since the last `make install`)
+// and the link fails with "undefined symbol" for osp_string_to_upper /
+// osprey_list_concat etc.
 func buildLibraryPaths(libName string) []string {
+	binaryDir := filepath.Dir(os.Args[0])
 	paths := []string{
 		fmt.Sprintf("bin/lib%s.a", libName),
 		fmt.Sprintf("./bin/lib%s.a", libName),
@@ -130,7 +137,10 @@ func buildLibraryPaths(libName string) []string {
 		fmt.Sprintf("../../../bin/lib%s.a", libName), // For deeper test directories
 		fmt.Sprintf("../../lib/lib%s.a", libName),    // For rust interop in tests/integration
 		fmt.Sprintf("../../../lib/lib%s.a", libName), // For rust interop in deeper test directories
-		filepath.Join(filepath.Dir(os.Args[0]), "..", fmt.Sprintf("lib%s.a", libName)),
+		filepath.Join(binaryDir, fmt.Sprintf("lib%s.a", libName)),       // binary/lib*.a
+		filepath.Join(binaryDir, "..", "lib", fmt.Sprintf("lib%s.a", libName)),   // binary/../lib/lib*.a
+		filepath.Join(binaryDir, "..", "bin", fmt.Sprintf("lib%s.a", libName)),   // binary/../bin/lib*.a
+		filepath.Join(binaryDir, "..", fmt.Sprintf("lib%s.a", libName)),
 		fmt.Sprintf("/usr/local/lib/lib%s.a", libName), // System install location
 	}
 

--- a/compiler/internal/codegen/jit_executor.go
+++ b/compiler/internal/codegen/jit_executor.go
@@ -144,8 +144,15 @@ func (j *JITExecutor) findAndAddRuntimeLibrary(libName string, linkArgs []string
 	return linkArgs
 }
 
-// buildRuntimeLibraryPaths builds search paths for a specific runtime library
+// buildRuntimeLibraryPaths builds search paths for a specific runtime library.
+// Compiler-binary-relative paths (binDir/bin and binDir/../lib) are
+// checked before the /usr/local/lib system install — without this, a
+// freshly built osprey run from outside the repo resolves stale system
+// libs (missing new runtime symbols added since the last `make install`)
+// and the link fails with "undefined symbol" for osp_string_to_upper /
+// osprey_list_concat etc.
 func (j *JITExecutor) buildRuntimeLibraryPaths(libName string) []string {
+	binaryDir := filepath.Dir(os.Args[0])
 	paths := []string{
 		fmt.Sprintf("bin/lib%s.a", libName),
 		fmt.Sprintf("./bin/lib%s.a", libName),
@@ -155,7 +162,10 @@ func (j *JITExecutor) buildRuntimeLibraryPaths(libName string) []string {
 		fmt.Sprintf("../../../bin/lib%s.a", libName), // For deeper test directories
 		fmt.Sprintf("../../lib/lib%s.a", libName),    // For rust interop in tests/integration
 		fmt.Sprintf("../../../lib/lib%s.a", libName), // For rust interop in deeper test directories
-		filepath.Join(filepath.Dir(os.Args[0]), "..", fmt.Sprintf("lib%s.a", libName)),
+		filepath.Join(binaryDir, fmt.Sprintf("lib%s.a", libName)),       // binary/lib*.a
+		filepath.Join(binaryDir, "..", "lib", fmt.Sprintf("lib%s.a", libName)),   // binary/../lib/lib*.a
+		filepath.Join(binaryDir, "..", "bin", fmt.Sprintf("lib%s.a", libName)),   // binary/../bin/lib*.a
+		filepath.Join(binaryDir, "..", fmt.Sprintf("lib%s.a", libName)),
 		fmt.Sprintf("/usr/local/lib/lib%s.a", libName), // System install location
 	}
 


### PR DESCRIPTION
## Summary
Running a freshly-built `bin/osprey` from outside the repo fell through to the stale `/usr/local/lib/lib*.a` from the last `make install`. New runtime symbols (`osp_string_to_upper`, `osp_string_split`, `osprey_list_concat`, etc.) weren't in those system archives, so the link failed with \"undefined symbol\" even though the fresh archives sat right next to the binary in `bin/`.

Inserted three compiler-binary-relative search paths ahead of the system path:
- `<binDir>/lib*.a`
- `<binDir>/../lib/lib*.a`
- `<binDir>/../bin/lib*.a`

Applied to both compilation.go (--compile) and jit_executor.go (--run); each keeps its own buildLibraryPaths.

## Test plan
- [x] `osprey /tmp/foo.osp --run` now links against the fresh `compiler/bin/libhttp_runtime.a` from outside the repo
- [x] `make test` green
- [x] `make lint` clean