### PR TITLE
fix(types): unify bare List/Map wildcard w/ List<string> + reject toString on opaque handles

### DIFF
--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -115,6 +115,13 @@ func (g *LLVMGenerator) generateToStringCall(callExpr *ast.CallExpression) (valu
 func (g *LLVMGenerator) convertValueToStringByType(
 	//TODO: types must not be passed around as strings. This is wrong.
 	theType string, arg value.Value) (value.Value, error) {
+	// Opaque-pointer collection / handle types share the i8* LLVM shape
+	// with string, so the i8*-fallback below would silently hand the raw
+	// runtime pointer to puts/printf and print garbage. Reject early so
+	// callers see a clear error instead.
+	if isOpaqueCollectionType(theType) {
+		return nil, fmt.Errorf("%w: type was '%s'", ErrToStringOpaque, theType)
+	}
 	// TODO: unhard code this!!! DO NOT IGNORE THIS! FIX IT!!
 	// but the actual LLVM value is a plain int, treat as int
 	if theType == "Result<int, Error>" && arg.Type() == types.I64 {
@@ -203,6 +210,22 @@ func (g *LLVMGenerator) convertValueToStringByType(
 		// For other complex types, return a generic representation
 		return g.createGlobalString(fmt.Sprintf("<%s>", theType)), nil
 	}
+}
+
+// isOpaqueCollectionType reports whether `theType` is one of the
+// runtime-backed types (List, Map) whose LLVM shape is i8* (an opaque
+// handle into the C runtime). These cannot be passed straight to puts
+// /printf as a string, so toString must refuse them rather than silently
+// emit a garbage-pointer load.
+func isOpaqueCollectionType(theType string) bool {
+	for _, prefix := range []string{TypeList, TypeMap} {
+		if theType == prefix ||
+			strings.HasPrefix(theType, prefix+"<") ||
+			strings.HasPrefix(theType, prefix+"[") {
+			return true
+		}
+	}
+	return false
 }
 
 // convertResultToString extracts the value from a Result type and converts it to string

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -64,6 +64,9 @@ var (
 	ErrUnsupportedCall    = errors.New("unsupported function call")
 	ErrToStringReserved   = errors.New("toString is a reserved function name")
 	ErrToStringOnUnit     = errors.New("toString does not accept a Unit-returning expression (e.g. print)")
+	ErrToStringOpaque     = errors.New(
+		"toString does not yet format opaque collection types — call listLength / mapKeys etc. first",
+	)
 	ErrPrintOnUnit        = errors.New("print does not accept a Unit-typed value (e.g. the result of another print)")
 
 	ErrWebSocketKeepAliveWrongArgs = errors.New("websocketKeepAlive function has wrong number of arguments")

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -1146,7 +1146,26 @@ func (ti *TypeInferer) unifyConcreteTypes(t1, t2 Type) bool {
 		return false
 	}
 
-	return ct1.name == ct2.name || ct1.name == TypeAny || ct2.name == TypeAny
+	if ct1.name == ct2.name || ct1.name == TypeAny || ct2.name == TypeAny {
+		return true
+	}
+
+	// WILDCARD: bare List/Map/Fiber/Channel unifies with its parameterised form
+	// represented as a ConcreteType like "List<string>". Built-in registries
+	// (collection_registry.go) declare signatures with the bare name so call
+	// sites passing e.g. List<string> (the unwrapped Success type of split())
+	// must still type-check.
+	return isWildcardConcreteMatch(ct1.name, ct2.name) || isWildcardConcreteMatch(ct2.name, ct1.name)
+}
+
+// isWildcardConcreteMatch reports whether bare matches a parameterised form
+// of the same wildcard kind, e.g. "List" matches "List<string>".
+func isWildcardConcreteMatch(bare, parameterised string) bool {
+	if !isBuiltInWildcardTypeName(bare) {
+		return false
+	}
+
+	return strings.HasPrefix(parameterised, bare+"<") && strings.HasSuffix(parameterised, ">")
 }
 
 // unifyPrimitiveTypesPair handles unification of PrimitiveType pairs


### PR DESCRIPTION
## Summary
- `listLength(splitValue)` and other collection builtins now accept `List<string>` (the unwrapped Success type of `split(...)`). `unifyConcreteTypes` previously only matched bare-vs-parameterised when one side was a `GenericType`; the ConcreteType case (`List` vs `List<string>`) was missing.
- `toString` now errors clearly when passed an opaque collection handle (`List`, `Map`). These share `i8*` with `string` so the prior fallback silently emitted a garbage pointer to `puts`/`printf`.

## Probe that motivated this

```osprey
fn main() -> Unit = {
    let result = split("a,b,c", ",")
    match result {
        Success { value } => print(toString(listLength(value)))
        Error { message } => print("err")
    }
}
```
Before: `function call type mismatch: actual=(List) -> int, expected=(List<string>) -> t2`
After: `3`

## Test plan
- [x] `make lint` clean
- [x] `go test ./tests/integration/...` passes
- [x] `go test ./tests/unit/...` passes
- [x] Manual repro above prints `3`