### PR TITLE
fix(codegen): toString on List/Map errors instead of printing garbage

### DIFF
--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -115,6 +115,13 @@ func (g *LLVMGenerator) generateToStringCall(callExpr *ast.CallExpression) (valu
 func (g *LLVMGenerator) convertValueToStringByType(
 	//TODO: types must not be passed around as strings. This is wrong.
 	theType string, arg value.Value) (value.Value, error) {
+	// Opaque-pointer collection types share the i8* LLVM shape with
+	// string, so the i8*-fallback below would silently hand the raw
+	// runtime pointer to puts/printf and print garbage. Reject early so
+	// callers see a clear error instead.
+	if isOpaqueCollectionType(theType) {
+		return nil, fmt.Errorf("%w: type was '%s'", ErrToStringOpaque, theType)
+	}
 	// TODO: unhard code this!!! DO NOT IGNORE THIS! FIX IT!!
 	// but the actual LLVM value is a plain int, treat as int
 	if theType == "Result<int, Error>" && arg.Type() == types.I64 {
@@ -203,6 +210,22 @@ func (g *LLVMGenerator) convertValueToStringByType(
 		// For other complex types, return a generic representation
 		return g.createGlobalString(fmt.Sprintf("<%s>", theType)), nil
 	}
+}
+
+// isOpaqueCollectionType reports whether `theType` is one of the
+// runtime-backed types (List, Map) whose LLVM shape is i8* (an opaque
+// handle into the C runtime). These cannot be passed straight to puts
+// /printf as a string, so toString must refuse them rather than silently
+// emit a garbage-pointer load.
+func isOpaqueCollectionType(theType string) bool {
+	for _, prefix := range []string{TypeList, TypeMap} {
+		if theType == prefix ||
+			strings.HasPrefix(theType, prefix+"<") ||
+			strings.HasPrefix(theType, prefix+"[") {
+			return true
+		}
+	}
+	return false
 }
 
 // convertResultToString extracts the value from a Result type and converts it to string

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -64,6 +64,9 @@ var (
 	ErrUnsupportedCall    = errors.New("unsupported function call")
 	ErrToStringReserved   = errors.New("toString is a reserved function name")
 	ErrToStringOnUnit     = errors.New("toString does not accept a Unit-returning expression (e.g. print)")
+	ErrToStringOpaque     = errors.New(
+		"toString does not yet format opaque collection types — call listLength / mapKeys etc. first",
+	)
 	ErrPrintOnUnit        = errors.New("print does not accept a Unit-typed value (e.g. the result of another print)")
 
 	ErrWebSocketKeepAliveWrongArgs = errors.New("websocketKeepAlive function has wrong number of arguments")


### PR DESCRIPTION
## Summary
`toString(xs)` where `xs : List<int>` returned the list's i8* runtime handle straight through. `print(toString(xs))` then handed that opaque pointer to puts, printing whatever bytes happen to live at the start of the runtime header. Same path for Map.

The i8*-identity fallback at the bottom of `convertValueToStringByType` treats any i8* as a formatted string, so List/Map silently piggy-backed on it.

Reject opaque collection types up-front with a clear error pointing at `listLength` / `mapKeys` / etc. as the workaround. Fiber and Channel keep the existing int-id path.

## Test plan
- [x] `let xs = listAppend(List(), 1); print(toString(xs))` now fails with the new error instead of printing garbage / nothing
- [x] `make test` green
- [x] `make lint` clean