### PR TITLE
fix(codegen): non-struct field-access suggests UFCS / function-call form

### DIFF
--- a/compiler/examples/failscompilation/field_access_on_result.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/field_access_on_result.ospo.expectedoutput
@@ -1,1 +1,1 @@
-line 5:13: cannot access field 'length' on non-struct type
+line 5:13: cannot access field 'length' on non-struct type - did you mean `length(stringVar)` or `stringVar.length()`?

--- a/compiler/examples/failscompilation/field_access_on_string.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/field_access_on_string.ospo.expectedoutput
@@ -1,1 +1,1 @@
-line 6:12: cannot access field 'length' on non-struct type
+line 6:12: cannot access field 'length' on non-struct type - did you mean `length(name)` or `name.length()`?

--- a/compiler/internal/codegen/expression_generation.go
+++ b/compiler/internal/codegen/expression_generation.go
@@ -1477,14 +1477,39 @@ func (g *LLVMGenerator) generateStructFieldAccess(
 		}
 	}
 
-	// If we can't find a record type, this is an error
+	// If we can't find a record type, this is an error. Append a hint
+	// when the field name matches a known function / builtin — users
+	// often type `s.length` expecting UFCS but bare-field access on a
+	// primitive type just fails without context.
+	hint := g.suggestFunctionForFieldAccess(fieldAccess.FieldName, fieldAccess.Object)
 	if fieldAccess.Position != nil {
-		return nil, fmt.Errorf("line %d:%d: cannot access field '%s' on non-struct type", //nolint:err113
-			fieldAccess.Position.Line, fieldAccess.Position.Column, fieldAccess.FieldName)
+		return nil, fmt.Errorf("line %d:%d: cannot access field '%s' on non-struct type%s", //nolint:err113
+			fieldAccess.Position.Line, fieldAccess.Position.Column, fieldAccess.FieldName, hint)
 	}
 
-	return nil, fmt.Errorf("cannot access field '%s' on non-struct type", //nolint:err113
-		fieldAccess.FieldName)
+	return nil, fmt.Errorf("cannot access field '%s' on non-struct type%s", //nolint:err113
+		fieldAccess.FieldName, hint)
+}
+
+// suggestFunctionForFieldAccess returns a "did you mean" hint when a
+// function/method with the same name exists; empty string otherwise.
+// Triggered from the non-struct field-access error path so e.g.
+// `s.length` on a string surfaces "did you mean `length(s)` or
+// `s.length()`?" instead of just "cannot access field".
+func (g *LLVMGenerator) suggestFunctionForFieldAccess(name string, object ast.Expression) string {
+	if g == nil || name == "" {
+		return ""
+	}
+	if _, ok := g.functions[name]; !ok {
+		if _, ok := GlobalBuiltInRegistry.GetFunction(name); !ok {
+			return ""
+		}
+	}
+	subject := "x"
+	if ident, ok := object.(*ast.Identifier); ok && ident.Name != "" {
+		subject = ident.Name
+	}
+	return fmt.Sprintf(" - did you mean `%s(%s)` or `%s.%s()`?", name, subject, subject, name)
 }
 
 // tryGetStructType extracts a struct type from an LLVM type


### PR DESCRIPTION
## Summary
`let s = \"hello\"; print(s.length)` failed with just \"cannot access field 'length' on non-struct type\" - accurate but unhelpful: users almost always typed the bare field expecting UFCS sugar for the existing `length(s)` / `s.length()` form.

Append a \"did you mean\" hint to the non-struct field-access error path when the field name resolves to a known function or builtin. Uses the actual receiver variable name when the object is an identifier; falls back to `x` otherwise.

Updated the two existing failscompilation fixtures whose expected output carries the new hint.

## Test plan
- [x] \`s.length\` on a string now reports the hint instead of the bare error
- [x] \`make test\` green
- [x] \`make lint\` clean