### PR TITLE
fix(errors): drop duplicate "on non-record type" in field-access error

### DIFF
--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -266,9 +266,12 @@ func WrapFieldNotFoundInRecord(field, recordType string) error {
 	return fmt.Errorf("%w '%s' in record type %s", ErrFieldNotFoundInRecord, field, recordType)
 }
 
-// WrapFieldAccessOnNonRecord wraps the non-record field access error with context
+// WrapFieldAccessOnNonRecord wraps the non-record field access error with context.
+// Sentinel already contains "on non-record type"; just append the field name and
+// the offending type so the message reads as one sentence instead of duplicating
+// the phrase ("...non-record type 'length' on non-record type string").
 func WrapFieldAccessOnNonRecord(field, typeStr string) error {
-	return fmt.Errorf("%w '%s' on non-record type %s", ErrFieldAccessOnNonRecord, field, typeStr)
+	return fmt.Errorf("%w '%s' (%s)", ErrFieldAccessOnNonRecord, field, typeStr)
 }
 
 // WrapFieldAccessOnLegacyRecord wraps the legacy record field access error


### PR DESCRIPTION
## Summary
- `WrapFieldAccessOnNonRecord` was re-appending the phrase already in the sentinel, producing messages like `cannot access field on non-record type 'length' on non-record type string`.
- Now reads `cannot access field on non-record type 'length' (string)`.

## Probe
```osprey
fn main() -> Unit = {
    let s = "hello"
    let len = s.length
}
```
Before: `cannot access field on non-record type 'length' on non-record type string`
After:  `cannot access field on non-record type 'length' (string)`

## Test plan
- [x] `make lint` clean
- [x] `go test ./tests/integration/...` passes
- [x] `go test ./tests/unit/...` passes