### PR TITLE
fix(codegen): listLength on Result<list> auto-unwraps before bitcast

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -153,7 +153,28 @@ func (g *LLVMGenerator) callOneArg(name string, ret types.Type, callExpr *ast.Ca
 // collection extern that takes an opaque handle. No-op if already i8* or
 // not a pointer. Needed when an expression returns a typed pointer
 // (e.g. osp_string_list*) that the runtime treats as an opaque list handle.
+//
+// Result-wrapped lists (`split(...)` returns Result<osp_string_list*>)
+// are auto-unwrapped first per spec 0004-TypeSystem.md — without this,
+// `listLength(splitResult)` bit-cast the *Result struct* pointer
+// straight to i8* and the runtime then read garbage from the
+// {ptr, disc} layout, returning a huge wrong length.
 func (g *LLVMGenerator) coerceToI8Ptr(v value.Value) value.Value {
+	if v.Type() == types.I8Ptr {
+		return v
+	}
+	const errorFlagBitSize = 8
+	if ptrTy, isPtr := v.Type().(*types.PointerType); isPtr {
+		if structTy, isStruct := ptrTy.ElemType.(*types.StructType); isStruct {
+			if len(structTy.Fields) == ResultFieldCount {
+				if intTy, ok := structTy.Fields[1].(*types.IntType); ok && intTy.BitSize == errorFlagBitSize {
+					vp := g.builder.NewGetElementPtr(structTy, v,
+						constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 0))
+					v = g.builder.NewLoad(structTy.Fields[0], vp)
+				}
+			}
+		}
+	}
 	if v.Type() == types.I8Ptr {
 		return v
 	}

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -266,9 +266,12 @@ func WrapFieldNotFoundInRecord(field, recordType string) error {
 	return fmt.Errorf("%w '%s' in record type %s", ErrFieldNotFoundInRecord, field, recordType)
 }
 
-// WrapFieldAccessOnNonRecord wraps the non-record field access error with context
+// WrapFieldAccessOnNonRecord wraps the non-record field access error with context.
+// Sentinel already contains "on non-record type"; just append the field name and
+// the offending type so the message reads as one sentence instead of duplicating
+// the phrase ("...non-record type 'length' on non-record type string").
 func WrapFieldAccessOnNonRecord(field, typeStr string) error {
-	return fmt.Errorf("%w '%s' on non-record type %s", ErrFieldAccessOnNonRecord, field, typeStr)
+	return fmt.Errorf("%w '%s' (%s)", ErrFieldAccessOnNonRecord, field, typeStr)
 }
 
 // WrapFieldAccessOnLegacyRecord wraps the legacy record field access error


### PR DESCRIPTION
## Summary
`"a,b,c".split(",") |> listLength` returned a huge garbage number (4357529152) instead of 3. split() returns `Result<osp_string_list*>` stored as a `{ptr, i8 disc}` struct on the stack; `listLength` then bit-cast that struct's outer pointer (the alloca) to `i8*` and asked the C runtime to read it as an `OspreyList`. The first 8 bytes of the Result struct are the inner ptr, not a length field, so the runtime read the pointer's bit pattern and returned it as a length.

Add a Result auto-unwrap in `coerceToI8Ptr`: when the value is a pointer to a 2-field struct `{T, i8}`, GEP+load field 0 first to get the inner T (the actual `osp_string_list*` / `OspreyList*` handle). Both list runtimes happen to keep `int64_t length` at offset 0, so once we hand the *inner* pointer to `osprey_list_length` the read returns the right value.

Per spec 0004-TypeSystem.md: `T` may flow into `Result<T,E>` slot and vice versa — the unwrap is the codegen complement of that rule.

## Test plan
- [x] `"a,b,c".split(",") |> listLength` now prints 3
- [x] `make test` green
- [x] `make lint` clean