### PR TITLE
fix(codegen): isResultType also checks discriminant-tag byte

### DIFF
--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -1168,15 +1168,29 @@ func (g *LLVMGenerator) isResultType(val value.Value) bool {
 	// Check for pointer to struct (legacy pointer semantics)
 	if ptrType, ok := val.Type().(*types.PointerType); ok {
 		if structType, ok := ptrType.ElemType.(*types.StructType); ok {
-			return len(structType.Fields) == ResultFieldCount
+			return isResultStructShape(structType)
 		}
 	}
 	// Check for struct value directly (value semantics)
 	if structType, ok := val.Type().(*types.StructType); ok {
-		return len(structType.Fields) == ResultFieldCount
+		return isResultStructShape(structType)
 	}
 
 	return false
+}
+
+// isResultStructShape reports whether a struct matches the Result<T, E>
+// codegen layout: 2 fields where the second is the i8 discriminant tag.
+// Records with two fields (e.g. `type Point = { x: int, y: int }` →
+// `{i64, i64}`) used to satisfy the old length-only check and were
+// silently formatted as `Error` by convertResultToString. The tag-byte
+// check distinguishes them.
+func isResultStructShape(st *types.StructType) bool {
+	if len(st.Fields) != ResultFieldCount {
+		return false
+	}
+
+	return st.Fields[1] == types.I8 || st.Fields[1] == types.I1
 }
 
 // generateStandardMatchExpression generates a standard (non-result) match expression.


### PR DESCRIPTION
## Summary
- `isResultType` previously treated any pointer-to-struct with 2 fields as a `Result`. Records like `type Point = { x: int, y: int }` lower to `{i64, i64}`, satisfying that check, so `toString(Point { x: 3, y: 4 })` silently routed through `convertResultToString` and printed literal `"Error"` (the non-string-error fallback inside that helper).
- Now also requires `Fields[1]` to be `i8` / `i1` — the codegen layout for Result is always `{T, i8}` (see `createDivisionByZeroError` and `llvm.go:1142`). Two-field records fall through to the generic `<typename>` path, which is honest about the missing user-facing toString impl.

## Probe
```osprey
type Point = { x: int, y: int }
fn main() -> Unit = {
    let p = Point { x: 3, y: 4 }
    print(toString(p))
}
```
Before: `Error`
After:  `<{x: int, y: int}>`

## Test plan
- [x] `make lint` clean
- [x] `go test ./tests/integration/...` passes
- [x] `go test ./tests/unit/...` passes