### PR TITLE
fix(codegen): primitive match without catch-all is now a compile error

### DIFF
--- a/compiler/internal/codegen/match_validation.go
+++ b/compiler/internal/codegen/match_validation.go
@@ -64,6 +64,17 @@ func (g *LLVMGenerator) validateMatchExhaustiveness(expr *ast.MatchExpression) e
 		return ensureBoolMatchExhaustive(expr)
 	}
 
+	// Same rationale for unbounded primitive types: int / float / string
+	// matches over literals fall through to the last arm at runtime if
+	// no wildcard / variable-bind catch-all is present, so
+	// `match x { 1 => "one" }` silently returns "one" for every input.
+	// Require an explicit catch-all to make the partial intent loud.
+	if typeName == TypeInt || typeName == TypeFloat || typeName == TypeString {
+		if !hasResultArms(expr) {
+			return ensurePrimitiveMatchHasCatchAll(expr, typeName)
+		}
+	}
+
 	// Check if this is a union type
 	typeDecl, exists := g.typeDeclarations[typeName]
 	if !exists {
@@ -123,6 +134,35 @@ func hasResultArms(expr *ast.MatchExpression) bool {
 		}
 	}
 	return false
+}
+
+// ensurePrimitiveMatchHasCatchAll errors when a match on an unbounded
+// primitive type (int / float / string) has no `_` or variable-bind
+// catch-all arm. Without one the lowered IR unconditionally branches to
+// the last arm, so `match x { 1 => "one" }` silently returns "one" for
+// every input — the same hazard ensureBoolMatchExhaustive fixed for bool.
+//
+// Variable-bind arms like `n => print("Many!")` parse as
+// `Constructor: "n", Variable: ""` (the AST builder can't tell at
+// parse time whether `n` names a union variant or binds a fresh
+// variable), so we treat any non-literal single identifier as a
+// catch-all for primitive matches — int/float/string have no named
+// variants.
+func ensurePrimitiveMatchHasCatchAll(expr *ast.MatchExpression, typeName string) error {
+	for _, arm := range expr.Arms {
+		if arm.Pattern.Constructor == "_" {
+			return nil
+		}
+		if arm.Pattern.Constructor == "" && arm.Pattern.Variable != "" {
+			return nil
+		}
+		// Non-literal single identifier on a primitive match = variable bind.
+		if arm.Pattern.Constructor != "" && !isLiteralPattern(arm.Pattern.Constructor) {
+			return nil
+		}
+	}
+	missing := fmt.Sprintf("_ (catch-all for %s)", typeName)
+	return WrapMatchNotExhaustiveWithPos([]string{missing}, expr.Position)
 }
 
 // ensureBoolMatchExhaustive errors when a boolean match misses either

--- a/compiler/tests/integration/full_integration_test.go
+++ b/compiler/tests/integration/full_integration_test.go
@@ -101,7 +101,7 @@ func TestBasicCompilation(t *testing.T) {
 		"simple_let":             `let x = 42`,
 		"simple_function":        `fn double(x) = x * 2`,
 		"simple_print":           `print(42)`,
-		"basic_match":            `let x = match 42 { 42 => 1 }`,
+		"basic_match":            "let x = match 42 { 42 => 1\n _ => 0 }",
 		"function_call":          `fn add(x, y) = x + y` + "\n" + `let result = add(x: 1, y: 2)`,
 		"string_interpolation":   `let name = "Alice"` + "\n" + `print("Hello ${name}")`,
 		"valid_type_declaration": `type Color = Red | Green | Blue`,

--- a/compiler/tests/unit/codegen/llvm_test.go
+++ b/compiler/tests/unit/codegen/llvm_test.go
@@ -164,7 +164,10 @@ match multResult {
 }
 
 func TestMatchExpression(t *testing.T) {
-	source := `let x = match 42 { 42 => 1 }
+	source := `let x = match 42 {
+  42 => 1
+  _ => 0
+}
 print(toString(x))`
 	testCompileAndRunWithOutput(t, source, "1", "match expression")
 }


### PR DESCRIPTION
## Summary
\`match x { 1 => \"one\" }\` compiled but the lowered IR unconditionally branched to the last arm — so every input returned \"one\" silently, even when nothing matched. Same hazard \`ensureBoolMatchExhaustive\` fixed for bool: extend the exhaustiveness check to int / float / string discriminants and require an explicit \`_\` wildcard or variable-bind catch-all arm.

Variable-bind arms parse as \`Constructor: \"n\", Variable: \"\"\` (the AST builder can't tell \`n\` from a union variant at parse time), so any single non-literal identifier is treated as a catch-all on primitive matches — int / float / string have no named variants.

## Test plan
- [x] \`match x { 1 => \"one\" }\` now reports \"match expression not exhaustive: missing patterns: [_ (catch-all for int)]\"
- [x] \`match x { 1 => \"one\"; _ => \"other\" }\` still works
- [x] \`match x { 1 => \"one\"; n => \"big\" }\` accepts the variable-bind catch-all
- [x] \`make test\` green, \`make lint\` clean. Existing fixtures updated where they relied on the silent fall-through