### PR TITLE
feat(stdlib): add mapGet builtin returning Result<V, string>

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -308,6 +308,44 @@ func (g *LLVMGenerator) generateMapContainsCall(callExpr *ast.CallExpression) (v
 	return g.builder.NewICmp(enum.IPredNE, res, constant.NewInt(types.I32, 0)), nil
 }
 
+// generateMapGetCall emits `match mapGet(m, k)` machinery:
+// - osprey_map_contains tells us whether the key exists
+// - on hit, osprey_map_get returns the stored i64 value (already boxed)
+// - wraps the value in a Result struct {i64, i8} where discriminant=0
+//   is Success and discriminant=1 is Error (key missing)
+func (g *LLVMGenerator) generateMapGetCall(callExpr *ast.CallExpression) (value.Value, error) {
+	if len(callExpr.Arguments) != collectionArgsTwo {
+		return nil, fmt.Errorf("mapGet expects %d arguments: %w", collectionArgsTwo, errCollectionArgCount)
+	}
+	g.declareMapExterns()
+	m, err := g.generateExpression(callExpr.Arguments[0])
+	if err != nil {
+		return nil, err
+	}
+	k, err := g.generateExpression(callExpr.Arguments[1])
+	if err != nil {
+		return nil, err
+	}
+	boxedKey := g.boxToI64(k)
+	contains := g.builder.NewCall(g.functions["osprey_map_contains"], m, boxedKey)
+	got := g.builder.NewCall(g.functions["osprey_map_get"], m, boxedKey)
+	// Result<i64, *> struct: {value, disc}. disc=1 (Error) when contains==0,
+	// else 0 (Success). Value field is osprey_map_get's raw i64 — already
+	// 0 on miss, but downstream code shouldn't read it through the Error
+	// arm anyway.
+	resultTy := types.NewStruct(types.I64, types.I8)
+	resultPtr := g.builder.NewAlloca(resultTy)
+	isMiss := g.builder.NewICmp(enum.IPredEQ, contains, constant.NewInt(types.I32, 0))
+	disc := g.builder.NewSelect(isMiss, constant.NewInt(types.I8, 1), constant.NewInt(types.I8, 0))
+	vp := g.builder.NewGetElementPtr(resultTy, resultPtr,
+		constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 0))
+	g.builder.NewStore(got, vp)
+	dp := g.builder.NewGetElementPtr(resultTy, resultPtr,
+		constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 1))
+	g.builder.NewStore(disc, dp)
+	return resultPtr, nil
+}
+
 func (g *LLVMGenerator) generateMapSetCall(callExpr *ast.CallExpression) (value.Value, error) {
 	if len(callExpr.Arguments) != collectionMapSetArg {
 		return nil, fmt.Errorf("mapSet expects %d arguments: %w", collectionMapSetArg, errCollectionArgCount)

--- a/compiler/internal/codegen/collection_registry.go
+++ b/compiler/internal/codegen/collection_registry.go
@@ -152,6 +152,19 @@ func (r *BuiltInFunctionRegistry) registerMapBuiltins() {
 		Generator:  (*LLVMGenerator).generateMapContainsCall,
 		Example:    `mapContains({"a": 1}, "a")  // true`,
 	}
+	r.functions["mapGet"] = &BuiltInFunction{
+		Name:        "mapGet",
+		Signature:   "mapGet(map: Map<K, V>, key: K) -> Result<V, string>",
+		Description: "Returns Success(value) when key is present, Error(...) otherwise.",
+		ParameterTypes: []BuiltInParameter{
+			mapParam,
+			{Name: "key", Type: anyT, Description: "Key to look up"},
+		},
+		ReturnType: anyT, // Result<V, string>; resolved via type inference.
+		Category:   CategoryFunctional,
+		Generator:  (*LLVMGenerator).generateMapGetCall,
+		Example:    `match mapGet(m, "k") { Success v => print(v); Error e => print("missing") }`,
+	}
 	r.functions["mapSet"] = &BuiltInFunction{
 		Name:        "mapSet",
 		Signature:   "mapSet(map: Map<K, V>, key: K, value: V) -> Map<K, V>",


### PR DESCRIPTION
## Summary
\`Map<K, V>\` exposed \`mapSet\` / \`mapContains\` / \`mapKeys\` / \`mapValues\` but no way to *read* a value by key without iterating the whole map — so users storing config in a map and looking it up had to work around through \`mapKeys\` + \`listContains\` + manual indexing.

The C runtime already had \`osprey_map_get\` implemented (returns int64_t with a sentinel 0 on miss); we just hadn't surfaced it. This wires the builtin through \`collection_registry\` and emits a \`Result<V, string>\` wrapper: \`osprey_map_contains\` gates the success / error discriminant, \`osprey_map_get\` supplies the value. The discriminant byte follows the existing Result layout \`{value, i8}\` so the standard Success / Error match arms work out of the box.

## Usage
\`\`\`osprey
match mapGet(m, \"k\") {
  Success v => print(v)
  Error e   => print(\"missing\")
}
\`\`\`

## Test plan
- [x] hit (\`mapGet(m, \"a\")\` where a=1) → Success(1)
- [x] miss (\`mapGet(m, \"missing\")\`) → Error arm fires
- [x] \`make test\` green, \`make lint\` clean