### PR TITLE
fix(codegen): variable-bind arm on primitive match now usable in body

### DIFF
--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -1252,11 +1252,34 @@ func (g *LLVMGenerator) generateMatchArmValues(
 
 // processMatchArm handles the processing of a single match arm
 func (g *LLVMGenerator) processMatchArm(arm ast.MatchArm, discriminant value.Value) (value.Value, error) {
-	if arm.Pattern.Variable != "" || len(arm.Pattern.Fields) > 0 {
+	if arm.Pattern.Variable != "" || len(arm.Pattern.Fields) > 0 || isPrimitiveVarBind(arm.Pattern, g) {
 		return g.processMatchArmWithBinding(arm, discriminant)
 	}
 
 	return g.processMatchArmWithoutBinding(arm)
+}
+
+// isPrimitiveVarBind reports whether `pattern` is a bare identifier
+// (Constructor="n", no Variable, no Fields) that's actually a
+// variable-bind catch-all on a primitive match — the AST builder
+// can't tell apart a constructor name from a fresh binding at parse
+// time. Treated as variable bind when the name doesn't resolve to any
+// known union variant or function.
+func isPrimitiveVarBind(pattern ast.Pattern, g *LLVMGenerator) bool {
+	if pattern.Constructor == "" || pattern.Constructor == "_" {
+		return false
+	}
+	if isLiteralPattern(pattern.Constructor) || isSpecialConstructor(pattern.Constructor) {
+		return false
+	}
+	for _, td := range g.typeDeclarations {
+		for _, v := range td.Variants {
+			if v.Name == pattern.Constructor {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // processMatchArmWithBinding handles match arms that have variable binding
@@ -1267,6 +1290,24 @@ func (g *LLVMGenerator) processMatchArmWithBinding(arm ast.MatchArm, discriminan
 	// Bind the pattern variable to the discriminant value
 	if arm.Pattern.Variable != "" {
 		g.variables[arm.Pattern.Variable] = discriminant
+	} else if isPrimitiveVarBind(arm.Pattern, g) {
+		// `n => …` on a primitive match: Constructor carries the name.
+		// Bind on both the codegen value map (so loads work) and the
+		// type inferer env (so the inferer can resolve `n` inside the
+		// arm body).
+		g.variables[arm.Pattern.Constructor] = discriminant
+		if g.typeInferer != nil && g.typeInferer.env != nil {
+			switch discriminant.Type() {
+			case types.I64:
+				g.typeInferer.env.Set(arm.Pattern.Constructor, &ConcreteType{name: TypeInt})
+			case types.Double:
+				g.typeInferer.env.Set(arm.Pattern.Constructor, &ConcreteType{name: TypeFloat})
+			case types.I8Ptr:
+				g.typeInferer.env.Set(arm.Pattern.Constructor, &ConcreteType{name: TypeString})
+			case types.I1:
+				g.typeInferer.env.Set(arm.Pattern.Constructor, &ConcreteType{name: TypeBool})
+			}
+		}
 	}
 
 	// Handle field extraction for structural matching and discriminated unions

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -791,6 +791,22 @@ func (ti *TypeInferer) InferPatternWithType(pattern ast.Pattern, discriminantTyp
 			return t, nil
 		}
 
+		// Variable-bind pattern on a primitive discriminant. The AST
+		// builder produces Constructor="n", Variable="" for `n => …`
+		// because at parse time a bare ID is ambiguous between a union
+		// variant and a fresh binding. When the discriminant is
+		// int/float/string (no named variants), bind the name to the
+		// discriminant type so the body can reference it.
+		if discriminantType != nil {
+			if ct, ok := ti.prune(discriminantType).(*ConcreteType); ok {
+				switch ct.name {
+				case TypeInt, TypeFloat, TypeString, TypeBool:
+					ti.env.Set(pattern.Constructor, ct)
+					return ct, nil
+				}
+			}
+		}
+
 		return nil, fmt.Errorf("%w: %s", ErrUnknownConstructor, pattern.Constructor)
 	}
 }


### PR DESCRIPTION
## Summary
\`match x { 0 => \"zero\"; n => toString(n) }\` on \`x : int\` failed with \"undefined variable: n\". The arm pattern parses as \`Constructor: \"n\", Variable: \"\"\` (the AST builder can't tell a fresh binding from a union variant at parse time), so both the inferer's literal/variant lookup and the codegen's binding step missed it.

Two changes:
1. **InferPatternWithType**: fall through to a variable-bind branch when the discriminant resolves to a primitive (int/float/string/bool). Bind the constructor name to the discriminant type in env so the body can reference it.
2. **processMatchArm**: detect the same shape via a new \`isPrimitiveVarBind\` helper (constructor isn't a literal, isn't a known union variant). Bind the name in both the codegen value map (so loads work) and the inferer env (so identifier lookups during codegen-time inference still resolve).

The existing \`classify_number(n)\` example accidentally worked because the body never referenced \`n\` — once the binding is used, the bug showed up.

## Test plan
- [x] \`match x { 0 => \"zero\"; n => toString(n) }\` now compiles and runs correctly
- [x] \`classify_number\` style (body doesn't use n) still works
- [x] \`make test\` green, \`make lint\` clean