### PR TITLE
fix(codegen): reject redefining a protected builtin at declaration time

### DIFF
--- a/compiler/internal/codegen/function_signatures.go
+++ b/compiler/internal/codegen/function_signatures.go
@@ -51,6 +51,19 @@ func (g *LLVMGenerator) declareFunctionSignature(fnDecl *ast.FunctionDeclaration
 		return ErrToStringReserved
 	}
 
+	// Reject redefining a protected builtin (`contains`, `length`,
+	// `print`, …). Without this the user's body still type-checks and
+	// the symbol gets registered, but the call-site arg validator
+	// matches the builtin's parameter names — so e.g.
+	// `fn contains(t: int, target: int)` then `contains(t: 5, target: 5)`
+	// fails with the misleading "contains expects exactly 2 arguments
+	// (s, needle), got 0" because the validator is using the builtin's
+	// signature. Fail loudly at declaration time instead.
+	protectedErr := CheckProtectedFunction(fnDecl)
+	if protectedErr != nil {
+		return protectedErr
+	}
+
 	// Store function declaration for monomorphization
 	if g.functionDeclarations == nil {
 		g.functionDeclarations = make(map[string]*ast.FunctionDeclaration)


### PR DESCRIPTION
## Summary
\`fn contains(t: int, target: int) -> bool = …\` declared the same name as the built-in \`contains(s: string, needle: string)\`. The user fn was registered, but the call-site validator matched the builtin's parameter names — so \`contains(t: 5, target: 5)\` failed with the misleading \"contains expects exactly 2 arguments (s, needle), got 0\" because the validator was checking the builtin's signature against the user's named args.

\`CheckProtectedFunction\` already existed but wasn't wired into the declaration path. Call it from \`declareFunctionSignature\` so the collision surfaces as the existing \"cannot redefine built-in function: contains\" error instead of the confusing arg-count message later.

## Test plan
- [x] \`fn contains(…)\` now errors at declaration time with \"cannot redefine built-in function: contains\"
- [x] Same applies to length / print / map / fold / etc.
- [x] \`make test\` green, \`make lint\` clean