### PR TITLE
fix(codegen): variant field auto-unwraps a sibling-widened Result struct

### DIFF
--- a/compiler/internal/codegen/expression_generation.go
+++ b/compiler/internal/codegen/expression_generation.go
@@ -2231,6 +2231,26 @@ func (g *LLVMGenerator) getTypeSize(t types.Type) int64 {
 	}
 }
 
+// tryUnwrapResultIntoExpected returns the inner value when v is a
+// Result struct {T, i8} and `expectedType` matches the inner T (per
+// spec 0004-TypeSystem.md auto-unwrap). Returns nil otherwise so the
+// caller can fall through to its other coercions.
+func (g *LLVMGenerator) tryUnwrapResultIntoExpected(v value.Value, expectedType types.Type) value.Value {
+	const errorFlagBitSize = 8
+	structTy, ok := v.Type().(*types.StructType)
+	if !ok || len(structTy.Fields) != ResultFieldCount {
+		return nil
+	}
+	intTy, ok := structTy.Fields[1].(*types.IntType)
+	if !ok || intTy.BitSize != errorFlagBitSize {
+		return nil
+	}
+	if structTy.Fields[0] != expectedType {
+		return nil
+	}
+	return g.builder.NewExtractValue(v, 0)
+}
+
 // convertValueToExpectedType converts a value to match the expected LLVM type
 //
 //nolint:gocognit // Complex function required for comprehensive type conversion handling
@@ -2240,6 +2260,14 @@ func (g *LLVMGenerator) convertValueToExpectedType(value value.Value, expectedTy
 	// If types already match, no conversion needed
 	if currentType == expectedType {
 		return value
+	}
+
+	// Auto-unwrap a Result struct {T, i8} when the target slot expects
+	// T. Without this, a sibling match arm that returns Result<int>
+	// widens the variant's inferred field type and constructing the
+	// *other* variant with a plain literal panics in serializeVariantFields.
+	if unwrapped := g.tryUnwrapResultIntoExpected(value, expectedType); unwrapped != nil {
+		return unwrapped
 	}
 
 	// Handle string types (i8*) explicitly


### PR DESCRIPTION
## Summary
\`type R = Ok { value: int } | Err { code: int, msg: string }\`, then \`fn check(n) = match n { 0 => Err{code:400,…}; _ => Ok{value:n*2} }\` panicked at compile time:

\`\`\`
panic: store operands are not compatible: src={i64,i8}; dst=i64*
\`\`\`

The \`_ => Ok{value:n*2}\` arm produces a \`Result<int>\` for the value field; the type inferer then widens the variant's value-field type across the union, so when we serialize the *other* variant the codegen tries to store a \`{i64,i8}\` struct into the variant's i64 field slot and panics in llir.

Detect the case in \`convertValueToExpectedType\`: if the source is a Result struct \`{T, i8}\` and the target slot is exactly \`T\`, ExtractValue the inner \`T\` before storing. Extracted into a small helper to keep the function under the cyclomatic-complexity limit.

Per spec 0004-TypeSystem.md, \`T\` flows transparently in/out of the \`Result<T,E>\` slot — this is the codegen complement of that rule, the same shape PR#96 added for listLength.

## Test plan
- [x] \`check(0)\` returns Err and prints \"zero\"
- [x] \`check(5)\` returns Ok and prints 10
- [x] \`make test\` green, \`make lint\` clean