### PR TITLE
fix(types): Success/Error arm binds variable even on non-Result discriminant

### DIFF
--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -852,15 +852,13 @@ func (ti *TypeInferer) handlePatternFieldBindings(pattern ast.Pattern, discrimin
 
 	// Handle Result type patterns
 	if pattern.Constructor == "Success" && discriminantType != nil {
-		if ti.bindSuccessPattern(pattern, discriminantType) {
-			return
-		}
+		ti.bindSuccessPattern(pattern, discriminantType)
+		return
 	}
 
 	if pattern.Constructor == "Error" && discriminantType != nil {
-		if ti.bindErrorPattern(pattern, discriminantType) {
-			return
-		}
+		ti.bindErrorPattern(pattern, discriminantType)
+		return
 	}
 
 	// Default behavior: assign fresh type variables
@@ -880,44 +878,54 @@ func patternBindName(pattern ast.Pattern) string {
 	return pattern.Variable
 }
 
-// bindSuccessPattern binds pattern fields for Success constructor
-func (ti *TypeInferer) bindSuccessPattern(pattern ast.Pattern, discriminantType Type) bool {
+// bindSuccessPattern binds pattern fields for Success constructor.
+// Codegen auto-wraps non-Result discriminants in Success (see
+// generateMatchExpressionWithDiscriminant), so a `Success v` arm always
+// binds — Result<T,E> maps v to T; any other discriminant maps v to its
+// own type. Without that fallback,
+// `match int_expr { Success v => double(v) }` raised
+// "undefined variable v" during arm-body inference.
+func (ti *TypeInferer) bindSuccessPattern(pattern ast.Pattern, discriminantType Type) {
 	name := patternBindName(pattern)
-	// Handle GenericType Result<T, E>
 	if gt, ok := discriminantType.(*GenericType); ok && gt.name == TypeResult && len(gt.typeArgs) >= 1 {
 		if name != "" {
 			ti.env.Set(name, gt.typeArgs[0])
 		}
-		return true
+		return
 	}
-	// Handle ConcreteType Result<T, E> (legacy string-based approach)
 	if ct, ok := discriminantType.(*ConcreteType); ok && strings.HasPrefix(ct.name, "Result<") {
 		if name != "" {
 			ti.env.Set(name, ti.extractResultSuccessType(ct.name))
 		}
-		return true
+		return
 	}
-	return false
+	if name != "" && discriminantType != nil {
+		ti.env.Set(name, discriminantType)
+	}
 }
 
-// bindErrorPattern binds pattern fields for Error constructor
-func (ti *TypeInferer) bindErrorPattern(pattern ast.Pattern, discriminantType Type) bool {
+// bindErrorPattern binds pattern fields for Error constructor.
+// Mirrors bindSuccessPattern — Result<T,E> binds to E; a non-Result
+// discriminant binds to a stand-in string (the auto-wrap path never
+// hits the Error branch at runtime, but the inferer still needs the
+// name in scope so the arm body type-checks).
+func (ti *TypeInferer) bindErrorPattern(pattern ast.Pattern, discriminantType Type) {
 	name := patternBindName(pattern)
-	// Handle GenericType Result<T, E>
 	if gt, ok := discriminantType.(*GenericType); ok && gt.name == "Result" && len(gt.typeArgs) >= 2 {
 		if name != "" {
 			ti.env.Set(name, gt.typeArgs[1])
 		}
-		return true
+		return
 	}
-	// Handle ConcreteType Result<T, E> (legacy string-based approach)
 	if ct, ok := discriminantType.(*ConcreteType); ok && strings.HasPrefix(ct.name, "Result<") {
 		if name != "" {
 			ti.env.Set(name, ti.extractResultErrorType(ct.name))
 		}
-		return true
+		return
 	}
-	return false
+	if name != "" {
+		ti.env.Set(name, &ConcreteType{name: TypeString})
+	}
 }
 
 // extractResultSuccessType extracts the success type T from Result<T, E>

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -881,10 +881,11 @@ func patternBindName(pattern ast.Pattern) string {
 // bindSuccessPattern binds pattern fields for Success constructor.
 // Codegen auto-wraps non-Result discriminants in Success (see
 // generateMatchExpressionWithDiscriminant), so a `Success v` arm always
-// binds — Result<T,E> maps v to T; any other discriminant maps v to its
-// own type. Without that fallback,
-// `match int_expr { Success v => double(v) }` raised
-// "undefined variable v" during arm-body inference.
+// binds — Result<T,E> maps v to T; a primitive discriminant maps v to
+// its own type. Type variables / unresolved discriminants get a fresh
+// tyvar so the arm-body unifier still has room to converge.
+// Without the primitive fallback, `match int_expr { Success v => v }`
+// raised "undefined variable v" during arm-body inference.
 func (ti *TypeInferer) bindSuccessPattern(pattern ast.Pattern, discriminantType Type) {
 	name := patternBindName(pattern)
 	if gt, ok := discriminantType.(*GenericType); ok && gt.name == TypeResult && len(gt.typeArgs) >= 1 {
@@ -899,16 +900,29 @@ func (ti *TypeInferer) bindSuccessPattern(pattern ast.Pattern, discriminantType 
 		}
 		return
 	}
-	if name != "" && discriminantType != nil {
-		ti.env.Set(name, discriminantType)
+	if name == "" {
+		return
 	}
+	// Bind primitive discriminants directly; otherwise hand out a fresh
+	// tyvar so the arm body can unify it against the Error arm without
+	// being constrained to the (possibly polymorphic) discriminant
+	// itself.
+	if ct, ok := discriminantType.(*ConcreteType); ok {
+		switch ct.name {
+		case TypeInt, TypeFloat, TypeString, TypeBool:
+			ti.env.Set(name, ct)
+			return
+		}
+	}
+	ti.env.Set(name, ti.Fresh())
 }
 
 // bindErrorPattern binds pattern fields for Error constructor.
-// Mirrors bindSuccessPattern — Result<T,E> binds to E; a non-Result
-// discriminant binds to a stand-in string (the auto-wrap path never
-// hits the Error branch at runtime, but the inferer still needs the
-// name in scope so the arm body type-checks).
+// Result<T,E> binds to E; otherwise hand out a fresh tyvar so the
+// arm body can unify without prematurely committing to a type.
+// The auto-wrap path never reaches the Error branch at runtime for
+// non-Result discriminants, but the inferer still needs the name in
+// scope so the body type-checks.
 func (ti *TypeInferer) bindErrorPattern(pattern ast.Pattern, discriminantType Type) {
 	name := patternBindName(pattern)
 	if gt, ok := discriminantType.(*GenericType); ok && gt.name == "Result" && len(gt.typeArgs) >= 2 {
@@ -924,7 +938,7 @@ func (ti *TypeInferer) bindErrorPattern(pattern ast.Pattern, discriminantType Ty
 		return
 	}
 	if name != "" {
-		ti.env.Set(name, &ConcreteType{name: TypeString})
+		ti.env.Set(name, ti.Fresh())
 	}
 }
 


### PR DESCRIPTION
## Summary
\`match double(5) { Success v => double(v); Error e => 0 }\` raised \"undefined variable v\" during arm-body inference even though codegen auto-wraps the int discriminant in a Success Result and extracts v back correctly at runtime — \`bindSuccessPattern\` returned false for non-Result discriminantTypes and the inferer never bound the name. Surfaced inside lambdas too (\`fn(x) => match inc(x) { Success v => double(v) }\`).

Make both helpers always bind. Result<T,E> still maps the name to T (Success) / E (Error). Bare concrete primitives (int/float/string/bool — the auto-wrap targets) bind to the discriminant's own type. Polymorphic / TypeVar discriminants get a fresh tyvar so the arm body can unify against the Error arm without being prematurely constrained — without that, \`match add(...) { Success { value } => value; Error { message } => 0 }\` on a polymorphic \`add\` would set value to the Result<...> tyvar wrapper itself and arm 1's literal 0 wouldn't unify.

Drop the bool return since both helpers now always handle the arm.

## Test plan
- [x] \`match int_expr { Success v => v }\` now binds v as int
- [x] \`match polymorphic_add() { Success { value } => value; Error { message } => 0 }\` still type-checks
- [x] Lambda-body case \`fn(x) => match inc(x) { Success gx => double(gx) }\` compiles
- [x] \`make test\` green (existing comprehensive example passes), \`make lint\` clean