### PR TITLE
fix(codegen): listContains string-equality + input() stdin SIGSEGV

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -258,7 +258,11 @@ func (g *LLVMGenerator) generateListContainsCall(callExpr *ast.CallExpression) (
 	// because the appended string and the literal \"a\" lived at
 	// different malloc'd addresses.
 	var eq value.Value
-	if needle.Type() == types.I8Ptr {
+	// Compare via String() — llir's I8Ptr global isn't always the same
+	// pointer-equal *types.PointerType as the runtime value's type, so
+	// the obvious `needle.Type() == types.I8Ptr` mis-routes string
+	// arguments to the integer-equality branch.
+	if needle.Type().String() == types.I8Ptr.String() {
 		elemPtr := g.builder.NewIntToPtr(elem, types.I8Ptr)
 		cmp := g.builder.NewCall(g.functions["strcmp"], elemPtr, needle)
 		eq = g.builder.NewICmp(enum.IPredEQ, cmp, constant.NewInt(types.I32, 0))

--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -253,7 +253,18 @@ func (g *LLVMGenerator) generateListContainsCall(callExpr *ast.CallExpression) (
 
 	g.builder = body
 	elem := g.builder.NewCall(getFn, list, idxLoad)
-	eq := g.builder.NewICmp(enum.IPredEQ, elem, g.boxToI64(needle))
+	// String needles want content-equality, not pointer-equality —
+	// without this, listContains([\"a\",\"b\"], \"a\") returned false
+	// because the appended string and the literal \"a\" lived at
+	// different malloc'd addresses.
+	var eq value.Value
+	if needle.Type() == types.I8Ptr {
+		elemPtr := g.builder.NewIntToPtr(elem, types.I8Ptr)
+		cmp := g.builder.NewCall(g.functions["strcmp"], elemPtr, needle)
+		eq = g.builder.NewICmp(enum.IPredEQ, cmp, constant.NewInt(types.I32, 0))
+	} else {
+		eq = g.builder.NewICmp(enum.IPredEQ, elem, g.boxToI64(needle))
+	}
 	foundBlock := g.function.NewBlock(fmt.Sprintf("contains_found_%p", callExpr))
 	contBlock := g.function.NewBlock(fmt.Sprintf("contains_cont_%p", callExpr))
 	g.builder.NewCondBr(eq, foundBlock, contBlock)

--- a/compiler/internal/codegen/constants.go
+++ b/compiler/internal/codegen/constants.go
@@ -35,6 +35,10 @@ const (
 	PercentEscape      = "%%"
 )
 
+// GOOSDarwin is the runtime.GOOS value for macOS, extracted as a const
+// to satisfy goconst (three+ call sites use it).
+const GOOSDarwin = "darwin"
+
 // Type names.
 const (
 	TypeString       = "string"

--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/christianfindlay/osprey/internal/ast"
@@ -11,6 +12,20 @@ import (
 	"github.com/llir/llvm/ir/types"
 	"github.com/llir/llvm/ir/value"
 )
+
+// stdinGlobalName returns the platform-specific external symbol name for
+// libc's stdin FILE*. macOS / *BSD export it as `__stdinp` (with double
+// underscore) via the C library's struct-of-three-FILEs idiom; glibc on
+// Linux and most others use plain `stdin`. Hardcoding "stdin" produced
+// `Undefined symbols: _stdin` at link time on macOS.
+func stdinGlobalName() string {
+	switch runtime.GOOS {
+	case GOOSDarwin, "freebsd", "netbsd", "openbsd", "dragonfly":
+		return "__stdinp"
+	default:
+		return "stdin"
+	}
+}
 
 // validateBuiltInArgs validates argument count for built-in functions using the registry
 func validateBuiltInArgs(funcName string, callExpr *ast.CallExpression) error {
@@ -468,8 +483,24 @@ func (g *LLVMGenerator) generateInputCall(callExpr *ast.CallExpression) (value.V
 		g.functions["fgets"] = fgetsFunc
 	}
 
-	// Use stdin directly - it's an external global in libc
-	stdinGlobal := g.module.NewGlobalDef("stdin", constant.NewNull(types.I8Ptr))
+	// `stdin` must be an *external* global so libc's FILE* is linked in.
+	// The previous NewGlobalDef(..., null) defined our own zero-initialised
+	// `i8** @stdin`, shadowing libc and handing fgets a NULL FILE* →
+	// SIGSEGV on the first read. The symbol name is platform-specific:
+	// macOS/*BSD export `__stdinp`; Linux/glibc uses `stdin`. Cache by
+	// name so repeated input() calls reuse one declaration.
+	stdinName := stdinGlobalName()
+	stdinGlobal, gok := g.globals[stdinName]
+	if !gok {
+		stdinGlobal = g.module.NewGlobal(stdinName, types.I8Ptr)
+		stdinGlobal.Linkage = enum.LinkageExternal
+
+		if g.globals == nil {
+			g.globals = make(map[string]*ir.Global)
+		}
+
+		g.globals[stdinName] = stdinGlobal
+	}
 
 	// Allocate buffer for input string (256 chars should be enough)
 	const inputBufferSize = 256
@@ -481,8 +512,14 @@ func (g *LLVMGenerator) generateInputCall(callExpr *ast.CallExpression) (value.V
 	bufferPtr := g.builder.NewGetElementPtr(types.NewArray(inputBufferSize, types.I8), inputBuffer,
 		constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 0))
 
+	// fgets takes the FILE* value, not a pointer-to-FILE*: load @stdin
+	// before passing it. The previous code handed the *address* of the
+	// global to fgets, which (combined with the null-init) made the
+	// segfault even more reliable.
+	stdinValue := g.builder.NewLoad(types.I8Ptr, stdinGlobal)
+
 	// Call fgets to read the string
-	fgetsResult := g.builder.NewCall(fgetsFunc, bufferPtr, bufferSize, stdinGlobal)
+	fgetsResult := g.builder.NewCall(fgetsFunc, bufferPtr, bufferSize, stdinValue)
 
 	// Create a Result<String, Error>
 	resultType := g.getResultType(types.I8Ptr)

--- a/compiler/internal/codegen/generator.go
+++ b/compiler/internal/codegen/generator.go
@@ -57,6 +57,9 @@ type LLVMGenerator struct {
 	// `xs |> map(f) |> filter(p)` filters on f(x), and
 	// `xs |> filter(p) |> map(f)` filters on x.
 	pendingIterOps []pendingIterOp
+	// Cache of declared module globals (e.g. external `@stdin`) so we
+	// don't redeclare on the second call site, which LLVM rejects.
+	globals map[string]*ir.Global
 }
 
 // pendingIterOp captures one pipeline stage (map or filter) plus its


### PR DESCRIPTION
## Summary

Two independent codegen fixes that landed on the same branch:

### listContains uses strcmp for string needles (Osprey2)
\`listContains([\"a\",\"b\"], \"a\")\` returned false because the appended \"a\" and the literal needle \"a\" lived at different malloc'd addresses, and listContains compared boxed i64 (pointer values) directly. When the needle is i8*, cast each element back to i8* and use \`strcmp(elem, needle) == 0\` instead. Detected via \`needle.Type().String() == types.I8Ptr.String()\` — llir's I8Ptr global isn't pointer-equal to runtime values for all build paths.

### input() no longer SIGSEGVs (Osprey1)
\`generateInputCall\` declared its own zero-initialised \`@stdin\` global, shadowing libc and handing fgets a NULL FILE*. Switched to a platform-aware external declaration (\`__stdinp\` on darwin/BSD, \`stdin\` on glibc) cached in a new \`g.globals\` map and loaded into the right FILE* value before being passed to fgets.

## Test plan
- [x] \`listContains([\"a\",\"b\"], \"a\")\` → true; \`listContains([1,2,3], 2)\` → true; \`listContains([1,2,3], 99)\` → false
- [x] \`let r = input()\` no longer crashes
- [x] \`make test\` green, \`make lint\` clean