### PR TITLE
feat(stdlib): add listGet, listSet, listDrop builtins

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -290,6 +290,67 @@ func (g *LLVMGenerator) generateListAppendCall(callExpr *ast.CallExpression) (va
 	return g.callTwoArgs("osprey_list_append", callExpr, true)
 }
 
+// generateListGetCall returns Result<T, string>. The runtime exposes
+// osprey_list_in_bounds + osprey_list_get separately; we use the
+// in-bounds check to gate the Success/Error discriminant.
+func (g *LLVMGenerator) generateListGetCall(callExpr *ast.CallExpression) (value.Value, error) {
+	if len(callExpr.Arguments) != collectionArgsTwo {
+		return nil, fmt.Errorf("listGet expects %d arguments: %w", collectionArgsTwo, errCollectionArgCount)
+	}
+	g.declareListExterns()
+	list, err := g.generateExpression(callExpr.Arguments[0])
+	if err != nil {
+		return nil, err
+	}
+	idx, err := g.generateExpression(callExpr.Arguments[1])
+	if err != nil {
+		return nil, err
+	}
+	list = g.coerceToI8Ptr(list)
+	idxI64 := g.boxToI64(idx)
+	inBounds := g.builder.NewCall(g.functions["osprey_list_in_bounds"], list, idxI64)
+	val := g.builder.NewCall(g.functions["osprey_list_get"], list, idxI64)
+	resultTy := types.NewStruct(types.I64, types.I8)
+	resultPtr := g.builder.NewAlloca(resultTy)
+	isOOB := g.builder.NewICmp(enum.IPredEQ, inBounds, constant.NewInt(types.I32, 0))
+	disc := g.builder.NewSelect(isOOB, constant.NewInt(types.I8, 1), constant.NewInt(types.I8, 0))
+	vp := g.builder.NewGetElementPtr(resultTy, resultPtr,
+		constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 0))
+	g.builder.NewStore(val, vp)
+	dp := g.builder.NewGetElementPtr(resultTy, resultPtr,
+		constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 1))
+	g.builder.NewStore(disc, dp)
+	return resultPtr, nil
+}
+
+// generateListSetCall returns a new list with the element at index
+// replaced. Out-of-range is a runtime no-op per the C runtime.
+func (g *LLVMGenerator) generateListSetCall(callExpr *ast.CallExpression) (value.Value, error) {
+	if len(callExpr.Arguments) != collectionMapSetArg {
+		return nil, fmt.Errorf("listSet expects %d arguments: %w", collectionMapSetArg, errCollectionArgCount)
+	}
+	g.declareListExterns()
+	list, err := g.generateExpression(callExpr.Arguments[0])
+	if err != nil {
+		return nil, err
+	}
+	idx, err := g.generateExpression(callExpr.Arguments[1])
+	if err != nil {
+		return nil, err
+	}
+	v, err := g.generateExpression(callExpr.Arguments[2])
+	if err != nil {
+		return nil, err
+	}
+	list = g.coerceToI8Ptr(list)
+	return g.builder.NewCall(g.functions["osprey_list_set"], list, g.boxToI64(idx), g.boxToI64(v)), nil
+}
+
+// generateListDropCall drops the leading N elements.
+func (g *LLVMGenerator) generateListDropCall(callExpr *ast.CallExpression) (value.Value, error) {
+	return g.callTwoArgs("osprey_list_drop", callExpr, true)
+}
+
 func (g *LLVMGenerator) generateListPrependCall(callExpr *ast.CallExpression) (value.Value, error) {
 	return g.callTwoArgs("osprey_list_prepend", callExpr, true)
 }

--- a/compiler/internal/codegen/collection_registry.go
+++ b/compiler/internal/codegen/collection_registry.go
@@ -40,6 +40,46 @@ func (r *BuiltInFunctionRegistry) registerListBuiltins() {
 		Generator:      (*LLVMGenerator).generateListLengthCall,
 		Example:        `listLength([1, 2, 3])  // 3`,
 	}
+	r.functions["listGet"] = &BuiltInFunction{
+		Name:        "listGet",
+		Signature:   "listGet(list: List<T>, index: int) -> Result<T, string>",
+		Description: "Returns Success(value) for an in-range index, Error otherwise. O(log32 n).",
+		ParameterTypes: []BuiltInParameter{
+			listParam,
+			{Name: "index", Type: intT, Description: "Zero-based element index"},
+		},
+		ReturnType: anyT, // Result<T, string>; element type via inference.
+		Category:   CategoryFunctional,
+		Generator:  (*LLVMGenerator).generateListGetCall,
+		Example:    `match listGet(xs, 0) { Success v => v; Error e => 0 }`,
+	}
+	r.functions["listSet"] = &BuiltInFunction{
+		Name:        "listSet",
+		Signature:   "listSet(list: List<T>, index: int, value: T) -> List<T>",
+		Description: "Returns a new list with the element at index replaced. Out-of-range is a no-op. O(log32 n).",
+		ParameterTypes: []BuiltInParameter{
+			listParam,
+			{Name: "index", Type: intT, Description: "Zero-based element index"},
+			{Name: "value", Type: anyT, Description: "Replacement value"},
+		},
+		ReturnType: list,
+		Category:   CategoryFunctional,
+		Generator:  (*LLVMGenerator).generateListSetCall,
+		Example:    `listSet([1, 2, 3], 1, 99)  // [1, 99, 3]`,
+	}
+	r.functions["listDrop"] = &BuiltInFunction{
+		Name:        "listDrop",
+		Signature:   "listDrop(list: List<T>, n: int) -> List<T>",
+		Description: "Returns a new list with the first n elements removed. O(log32 n).",
+		ParameterTypes: []BuiltInParameter{
+			listParam,
+			{Name: "n", Type: intT, Description: "Number of leading elements to drop"},
+		},
+		ReturnType: list,
+		Category:   CategoryFunctional,
+		Generator:  (*LLVMGenerator).generateListDropCall,
+		Example:    `listDrop([1, 2, 3, 4], 2)  // [3, 4]`,
+	}
 	r.functions["listAppend"] = &BuiltInFunction{
 		Name:        "listAppend",
 		Signature:   "listAppend(list: List<T>, value: T) -> List<T>",


### PR DESCRIPTION
## Summary
Three \`List<T>\` ops were already implemented in the C runtime (\`osprey_list_get\` / \`osprey_list_set\` / \`osprey_list_drop\`) and even declared in \`declareListExterns\`, but never surfaced as user-callable builtins. Users could iterate via \`forEachList\` but couldn't read by index, replace an element, or trim the head — they had to either reach into the runtime or rebuild the list with \`listAppend\`.

- \`listGet(list, i) -> Result<T, string>\` — uses \`osprey_list_in_bounds\` to gate the Success/Error discriminant, then \`osprey_list_get\` for the value. Mirrors \`mapGet\`'s shape (PR#99).
- \`listSet(list, i, v) -> List<T>\` — direct \`osprey_list_set\` wrapper. Out-of-range is a runtime no-op (preserves the input list).
- \`listDrop(list, n) -> List<T>\` — direct \`osprey_list_drop\` wrapper.

## Usage
\`\`\`osprey
match listGet(xs, 0) { Success v => v; Error e => 0 }
let updated = listSet(xs, 1, 99)
let tail    = listDrop(xs, 1)
\`\`\`

## Test plan
- [x] \`listGet(xs, 0)\` returns Success(value) for in-range, Error for OOB
- [x] \`listSet(xs, 1, 99)\` replaces middle element, leaves head/tail intact
- [x] \`listDrop(xs, 2)\` drops first 2 elements
- [x] \`make test\` green, \`make lint\` clean