### PR TITLE
fix(types): let annotation auto-unwraps Result<T,E> into T slot

### DIFF
--- a/compiler/internal/codegen/statement_generation.go
+++ b/compiler/internal/codegen/statement_generation.go
@@ -249,11 +249,20 @@ func (g *LLVMGenerator) generateLetDeclaration(letDecl *ast.LetDeclaration) (val
 			return nil, err
 		}
 
-		// Check if the value type is compatible with the annotation
+		// Check if the value type is compatible with the annotation.
+		// Spec auto-unwrap (0004-TypeSystem.md) allows Result<T,E> to flow
+		// into a T-typed slot — mirror the mut-assign path so e.g.
+		// `let r: int = 5 + 3` (RHS is Result<int, MathError>) succeeds.
 		err = g.typeInferer.Unify(annotatedType, valueType)
 		if err != nil {
-			return nil, WrapTypeMismatchWithPos(
-				valueType.String(), letDecl.Name, annotatedType.String(), letDecl.Position)
+			unwrappedValue := g.typeInferer.unwrapResultType(valueType)
+			unwrapErr := g.typeInferer.Unify(annotatedType, unwrappedValue)
+			if unwrapErr != nil {
+				return nil, WrapTypeMismatchWithPos(
+					valueType.String(), letDecl.Name, annotatedType.String(), letDecl.Position)
+			}
+			value = g.unwrapIfResult(value)
+			g.variables[letDecl.Name] = value
 		}
 
 		varType = annotatedType


### PR DESCRIPTION
## Summary
\`let r: int = 5 + 3\` failed with \"cannot assign Result<int, MathError> to variable 'r' of type int\" — the let-declaration path called \`Unify(annotated, value)\` directly and never retried with the Result wrapper stripped, even though the existing mut-assign path (\`generateAssignmentStatement\`) already does this dance for the same spec reason (0004-TypeSystem.md auto-unwrap).

Mirror the assign path: on unify failure, try \`Unify(annotated, unwrapResult(value))\`; if that succeeds, also \`unwrapIfResult\` the runtime value so the variable holds a raw T instead of a Result struct.

Without this, every explicitly-typed numeric let forced the user to wrap the RHS in a \`match … { Success v => v; Error e => 0 }\`.

## Test plan
- [x] \`let r: int = 5 + 3\` now binds r=8
- [x] Untyped lets (no annotation) unchanged
- [x] \`make test\` green, \`make lint\` clean