### PR TITLE
fix(runtime): osprey_list_get rejects out-of-range indices instead of SIGSEGV

### DIFF
--- a/compiler/runtime/list_runtime.c
+++ b/compiler/runtime/list_runtime.c
@@ -97,6 +97,15 @@ static int64_t tail_offset(OspreyList *l) {
 }
 
 int64_t osprey_list_get(OspreyList *l, int64_t i) {
+  /* Out-of-range indices (negative or past end) used to walk the trie
+   * with garbage shifts and dereference NULL/uninit nodes — SIGSEGV.
+   * Codegen calls osprey_list_in_bounds first to set the Result
+   * discriminant, but the value-side call still ran with the OOB
+   * index. Return 0 here so the caller's in-bounds check picks the
+   * Error variant cleanly. */
+  if (l == NULL || i < 0 || i >= l->length) {
+    return 0;
+  }
   int64_t off = tail_offset(l);
   if (i >= off) {
     return l->tail->slots[i - off];


### PR DESCRIPTION
## Summary
`osprey_list_get` assumed `i` was in `[0, length)`. With `i = -1` (or past end) it walked the trie with garbage shifts and dereferenced NULL/uninit nodes — SIGSEGV. Codegen calls `osprey_list_in_bounds` first to set the `Result<T, string>` discriminant, but the value-side call still ran with the OOB index.

## Probe
```osprey
fn main() -> Unit = {
    let xs = listAppend(listAppend(List(), 1), 2)
    match listGet(xs, -1) {
        Success { value } => print(toString(value))
        Error { message } => print("err")
    }
}
```
Before: `signal: segmentation fault`
After:  `err`

## Test plan
- [x] `make lint` clean
- [x] `go test ./tests/integration/...` passes
- [x] `go test ./tests/unit/...` passes