### PR TITLE
fix(codegen): match var-bind on non-primitive + immediately-invoked lambda args

### DIFF
--- a/compiler/internal/ast/builder_calls.go
+++ b/compiler/internal/ast/builder_calls.go
@@ -197,9 +197,25 @@ func (b *Builder) buildSimpleCall(ctx parser.ICallExprContext, primary Expressio
 		args, namedArgs = b.buildArguments(ctx.ArgList(0))
 	}
 
+	// Identifier callee (the common path) — wrap in CallExpression.
 	if ident, ok := primary.(*Identifier); ok {
 		return &CallExpression{
 			Function:       ident,
+			Arguments:      args,
+			NamedArguments: namedArgs,
+			Position:       b.getPositionFromContext(ctx),
+		}
+	}
+
+	// Immediately-invoked lambdas and other parenthesized callee
+	// expressions: `(fn(x: int) => x * 10)(5)`. Previously this dropped
+	// the (5) args and returned just the lambda, so print(lambda)(5)
+	// silently puts'd the lambda's function pointer. Wrap in
+	// CallExpression — codegen's resolveFunctionValue handles the
+	// non-identifier case via funcName=="" → generateExpression(Function).
+	if _, isLambda := primary.(*LambdaExpression); isLambda {
+		return &CallExpression{
+			Function:       primary,
 			Arguments:      args,
 			NamedArguments: namedArgs,
 			Position:       b.getPositionFromContext(ctx),

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -1325,6 +1325,13 @@ func (g *LLVMGenerator) processMatchArmWithBinding(arm ast.MatchArm, discriminan
 			// string literals. Compare by shape via primitiveInferType.
 			if t := primitiveInferType(discriminant.Type()); t != "" {
 				g.typeInferer.env.Set(arm.Pattern.Constructor, &ConcreteType{name: t})
+			} else {
+				// Non-primitive discriminant (Result struct, record, …): bind
+				// to a fresh TypeVar so inferer lookups in the arm body don't
+				// fail with "undefined variable". The runtime value lives in
+				// g.variables already; toString / pattern destructuring resolve
+				// off the LLVM type, not the inferer name.
+				g.typeInferer.env.Set(arm.Pattern.Constructor, g.typeInferer.Fresh())
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Two independent fixes that landed on the same branch:

### match var-bind on non-primitive discriminant (Osprey1)
PR#100 added primitive-match var-bind. Non-primitive (e.g. union variant) discriminants still crashed the inferer.

### immediately-invoked lambda no longer drops its args (Osprey2)
\`print((fn(x: int) => x * 10)(5))\` printed nothing — and worse, emitted \`puts(i64 (i64)* @lambda_12)\`, handing puts a raw function pointer. \`buildSimpleCall\` only wrapped a primary in \`CallExpression\` when the primary was an Identifier; \`LambdaExpression\`-shaped primaries were returned as-is, dropping the \`(5)\` argument list silently. Wrap LambdaExpression callees in CallExpression too — codegen's \`resolveFunctionValue\` already handles the non-Identifier case via \`funcName == "" → generateExpression(callExpr.Function)\`.

## Test plan
- [x] \`(fn(x: int) => x * 10)(5)\` returns 50
- [x] Non-primitive var-bind no longer crashes
- [x] \`make test\` green, \`make lint\` clean