### PR TITLE
fix(codegen): duplicate fn declaration errors at source level instead of LLC crash

### DIFF
--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -30,8 +30,9 @@ var (
 	ErrSuccessConstructorMissingValue = errors.New("success constructor requires 'value' field")
 	ErrErrorConstructorMissingMessage = errors.New("error constructor requires 'message' field")
 
-	ErrFunctionNotDeclared = errors.New("function not declared")
-	ErrNotAFunction        = errors.New("type is not a function")
+	ErrFunctionNotDeclared    = errors.New("function not declared")
+	ErrFunctionAlreadyDeclared = errors.New("function already declared")
+	ErrNotAFunction           = errors.New("type is not a function")
 
 	ErrNoVariantFound     = errors.New("no variant found matching field structure")
 	ErrNoVariantsFound    = errors.New("no variants found for type")
@@ -391,6 +392,17 @@ func WrapBuiltInTwoArgs(funcName string) error {
 // WrapFunctionNotDeclared wraps function not declared errors
 func WrapFunctionNotDeclared(funcName string) error {
 	return WrapSimpleError(ErrFunctionNotDeclared, funcName)
+}
+
+// WrapFunctionAlreadyDeclared wraps the duplicate-declaration error with
+// position info so the user sees the second declaration site.
+func WrapFunctionAlreadyDeclared(funcName string, pos any) error {
+	if position, ok := pos.(*ast.Position); ok && position != nil {
+		return fmt.Errorf("line %d:%d: %w: %s",
+			position.Line, position.Column, ErrFunctionAlreadyDeclared, funcName)
+	}
+
+	return fmt.Errorf("%w: %s", ErrFunctionAlreadyDeclared, funcName)
 }
 
 // WrapUndefinedVariable wraps undefined variable errors

--- a/compiler/internal/codegen/function_signatures.go
+++ b/compiler/internal/codegen/function_signatures.go
@@ -64,9 +64,17 @@ func (g *LLVMGenerator) declareFunctionSignature(fnDecl *ast.FunctionDeclaration
 		return protectedErr
 	}
 
-	// Store function declaration for monomorphization
+	// Store function declaration for monomorphization. Reject duplicate
+	// declarations up-front — without this the second `fn foo(...)` silently
+	// overwrites the first in the inferer env, then both compete during
+	// codegen and LLC fails with the cryptic "invalid redefinition of
+	// function 'foo'" INTERNAL_COMPILER_ERROR. Surface a clean source-level
+	// error instead.
 	if g.functionDeclarations == nil {
 		g.functionDeclarations = make(map[string]*ast.FunctionDeclaration)
+	}
+	if _, exists := g.functionDeclarations[fnDecl.Name]; exists {
+		return WrapFunctionAlreadyDeclared(fnDecl.Name, fnDecl.Position)
 	}
 
 	g.functionDeclarations[fnDecl.Name] = fnDecl


### PR DESCRIPTION
## Summary
Two `fn foo(...)` declarations silently overwrote each other in the inferer env, then both reached codegen and LLC failed with
  `INTERNAL_COMPILER_ERROR: invalid redefinition of function 'foo'`
no source position, looks like a compiler bug.

Reject the second declaration up-front in `declareFunctionSignature`.

## Probe
```osprey
fn add(a: int, b: int) -> int = a + b
fn add(a: int, b: int) -> int = a - b
fn main() -> Unit = {
    print(toString(add(a: 5, b: 3)))
}
```
Before: `INTERNAL_COMPILER_ERROR: failed to compile IR: ... invalid redefinition of function 'add'`
After:  `line 2:0: function already declared: add`

## Test plan
- [x] `make lint` clean
- [x] `go test ./tests/integration/...` passes
- [x] `go test ./tests/unit/...` passes