### PR TITLE
fix(codegen): duplicate named arguments error + mapList/filterList/foldList builtins

### DIFF
--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -583,3 +583,151 @@ func (g *LLVMGenerator) generateForEachListCall(callExpr *ast.CallExpression) (v
 	g.builder = loopEnd
 	return list, nil
 }
+
+// generateMapListCall builds a new List<T> by applying a transform
+// function to each element. Mirrors generateForEachListCall's counted
+// loop but pushes each f(x) into an osprey_list_builder.
+func (g *LLVMGenerator) generateMapListCall(callExpr *ast.CallExpression) (value.Value, error) {
+	return g.generateListBuilderLoop(callExpr, "mapList", false /* filter */)
+}
+
+// generateFilterListCall builds a new List<T> containing only elements
+// where the predicate returns truthy.
+func (g *LLVMGenerator) generateFilterListCall(callExpr *ast.CallExpression) (value.Value, error) {
+	return g.generateListBuilderLoop(callExpr, "filterList", true /* filter */)
+}
+
+// generateListBuilderLoop implements both mapList and filterList. The
+// `filter` flag flips whether the callback's return value is the new
+// element (map) or a bool that decides whether to push the original
+// element (filter).
+func (g *LLVMGenerator) generateListBuilderLoop(
+	callExpr *ast.CallExpression, name string, filter bool,
+) (value.Value, error) {
+	if len(callExpr.Arguments) != collectionArgsTwo {
+		return nil, fmt.Errorf("%s expects %d arguments: %w", name, collectionArgsTwo, errCollectionArgCount)
+	}
+	g.declareListExterns()
+	list, err := g.generateExpression(callExpr.Arguments[0])
+	if err != nil {
+		return nil, err
+	}
+	if list.Type() != types.I8Ptr {
+		return nil, fmt.Errorf("%w: %s currently requires a runtime-allocated list "+
+			"(built with List() / listAppend / split / ...)",
+			errCollectionExternMiss, name)
+	}
+	funcIdent, err := g.resolveCallbackIdent(callExpr.Arguments[1], errForEachListSecondArg)
+	if err != nil {
+		return nil, err
+	}
+
+	lenFn := g.functions["osprey_list_length"]
+	getFn := g.functions["osprey_list_get"]
+	pushFn := g.functions["osprey_list_builder_push"]
+	sealFn := g.functions["osprey_list_builder_seal"]
+	bld := g.builder.NewCall(g.functions["osprey_list_builder_new"])
+	listLen := g.builder.NewCall(lenFn, list)
+	idxPtr := g.builder.NewAlloca(types.I64)
+	g.builder.NewStore(constant.NewInt(types.I64, 0), idxPtr)
+
+	loopCond := g.function.NewBlock(fmt.Sprintf("%s_cond_%p", name, callExpr))
+	loopBody := g.function.NewBlock(fmt.Sprintf("%s_body_%p", name, callExpr))
+	loopEnd := g.function.NewBlock(fmt.Sprintf("%s_end_%p", name, callExpr))
+	g.builder.NewBr(loopCond)
+
+	g.builder = loopCond
+	idx := g.builder.NewLoad(types.I64, idxPtr)
+	g.builder.NewCondBr(g.builder.NewICmp(enum.IPredSLT, idx, listLen), loopBody, loopEnd)
+
+	g.builder = loopBody
+	elem := g.builder.NewCall(getFn, list, idx)
+	cbResult, err := g.callFunctionWithValue(funcIdent, elem)
+	if err != nil {
+		return nil, err
+	}
+	if filter {
+		// Push elem when predicate truthy. Predicate result may be i1 or
+		// i64 — compare against zero of its own int width.
+		intTy, ok := cbResult.Type().(*types.IntType)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s predicate must return int/bool", errCollectionExternMiss, name)
+		}
+		isTrue := g.builder.NewICmp(enum.IPredNE, cbResult, constant.NewInt(intTy, 0))
+		pushBlock := g.function.NewBlock(fmt.Sprintf("%s_push_%p", name, callExpr))
+		skipBlock := g.function.NewBlock(fmt.Sprintf("%s_skip_%p", name, callExpr))
+		g.builder.NewCondBr(isTrue, pushBlock, skipBlock)
+		g.builder = pushBlock
+		g.builder.NewCall(pushFn, bld, elem)
+		g.builder.NewBr(skipBlock)
+		g.builder = skipBlock
+	} else {
+		// Map: push the transformed value (boxed to i64).
+		g.builder.NewCall(pushFn, bld, g.boxToI64(cbResult))
+	}
+	next := g.builder.NewAdd(idx, constant.NewInt(types.I64, 1))
+	g.builder.NewStore(next, idxPtr)
+	g.builder.NewBr(loopCond)
+
+	g.builder = loopEnd
+	return g.builder.NewCall(sealFn, bld), nil
+}
+
+// generateFoldListCall reduces a List<T> with an accumulator via the
+// user's combining function. Mirrors the range-fold loop in
+// iterator_generation.go, but reads list elements via
+// osprey_list_get instead of a counter.
+func (g *LLVMGenerator) generateFoldListCall(callExpr *ast.CallExpression) (value.Value, error) {
+	if len(callExpr.Arguments) != collectionMapSetArg { // 3 args: list, initial, fn
+		return nil, fmt.Errorf("foldList expects %d arguments: %w", collectionMapSetArg, errCollectionArgCount)
+	}
+	g.declareListExterns()
+	list, err := g.generateExpression(callExpr.Arguments[0])
+	if err != nil {
+		return nil, err
+	}
+	if list.Type() != types.I8Ptr {
+		return nil, fmt.Errorf("%w: foldList currently requires a runtime-allocated list "+
+			"(built with List() / listAppend / split / ...)",
+			errCollectionExternMiss)
+	}
+	initial, err := g.generateExpression(callExpr.Arguments[1])
+	if err != nil {
+		return nil, err
+	}
+	funcIdent, err := g.resolveCallbackIdent(callExpr.Arguments[2], errForEachListSecondArg)
+	if err != nil {
+		return nil, err
+	}
+
+	lenFn := g.functions["osprey_list_length"]
+	getFn := g.functions["osprey_list_get"]
+	listLen := g.builder.NewCall(lenFn, list)
+	accPtr := g.builder.NewAlloca(types.I64)
+	g.builder.NewStore(g.boxToI64(initial), accPtr)
+	idxPtr := g.builder.NewAlloca(types.I64)
+	g.builder.NewStore(constant.NewInt(types.I64, 0), idxPtr)
+
+	loopCond := g.function.NewBlock(fmt.Sprintf("foldlist_cond_%p", callExpr))
+	loopBody := g.function.NewBlock(fmt.Sprintf("foldlist_body_%p", callExpr))
+	loopEnd := g.function.NewBlock(fmt.Sprintf("foldlist_end_%p", callExpr))
+	g.builder.NewBr(loopCond)
+
+	g.builder = loopCond
+	idx := g.builder.NewLoad(types.I64, idxPtr)
+	g.builder.NewCondBr(g.builder.NewICmp(enum.IPredSLT, idx, listLen), loopBody, loopEnd)
+
+	g.builder = loopBody
+	elem := g.builder.NewCall(getFn, list, idx)
+	acc := g.builder.NewLoad(types.I64, accPtr)
+	newAcc, err := g.callFunctionWithTwoValues(funcIdent, acc, elem)
+	if err != nil {
+		return nil, err
+	}
+	g.builder.NewStore(g.boxToI64(newAcc), accPtr)
+	g.builder.NewStore(g.builder.NewAdd(idx, constant.NewInt(types.I64, 1)), idxPtr)
+	g.builder.NewBr(loopCond)
+
+	g.builder = loopEnd
+	return g.builder.NewLoad(types.I64, accPtr), nil
+}

--- a/compiler/internal/codegen/collection_registry.go
+++ b/compiler/internal/codegen/collection_registry.go
@@ -143,6 +143,49 @@ func (r *BuiltInFunctionRegistry) registerListBuiltins() {
 		Generator:   (*LLVMGenerator).generateForEachListCall,
 		Example:     `forEachList(xs, print)`,
 	}
+	r.functions["mapList"] = &BuiltInFunction{
+		Name:        "mapList",
+		Signature:   "mapList(list: List<T>, function: fn(T) -> U) -> List<U>",
+		Description: "Returns a new list with function applied to every element. O(n).",
+		ParameterTypes: []BuiltInParameter{
+			listParam,
+			{Name: "function", Type: anyT, Description: "Transform applied per element"},
+		},
+		ReturnType:  list,
+		Category:    CategoryFunctional,
+		IsProtected: true,
+		Generator:   (*LLVMGenerator).generateMapListCall,
+		Example:     `mapList(xs, fn(x: int) => x * 2)`,
+	}
+	r.functions["filterList"] = &BuiltInFunction{
+		Name:        "filterList",
+		Signature:   "filterList(list: List<T>, predicate: fn(T) -> bool) -> List<T>",
+		Description: "Returns a new list with only elements where predicate is true. O(n).",
+		ParameterTypes: []BuiltInParameter{
+			listParam,
+			{Name: "predicate", Type: anyT, Description: "Bool-valued predicate"},
+		},
+		ReturnType:  list,
+		Category:    CategoryFunctional,
+		IsProtected: true,
+		Generator:   (*LLVMGenerator).generateFilterListCall,
+		Example:     `filterList(xs, fn(x: int) => x > 0)`,
+	}
+	r.functions["foldList"] = &BuiltInFunction{
+		Name:        "foldList",
+		Signature:   "foldList(list: List<T>, initial: U, fn: fn(U, T) -> U) -> U",
+		Description: "Reduces the list to a single value, starting from initial. O(n).",
+		ParameterTypes: []BuiltInParameter{
+			listParam,
+			{Name: "initial", Type: anyT, Description: "Initial accumulator value"},
+			{Name: "function", Type: anyT, Description: "Combining function (acc, elem) -> acc"},
+		},
+		ReturnType:  anyT,
+		Category:    CategoryFunctional,
+		IsProtected: true,
+		Generator:   (*LLVMGenerator).generateFoldListCall,
+		Example:     `foldList(xs, 0, fn(acc, x) => acc + x)`,
+	}
 	// `contains` on List is registered here; the Map version below would
 	// otherwise clash on name. The codegen helper inspects the inferred
 	// receiver type to dispatch.

--- a/compiler/internal/codegen/match_validation.go
+++ b/compiler/internal/codegen/match_validation.go
@@ -246,8 +246,20 @@ func (g *LLVMGenerator) reorderNamedArguments(fnName string, args []ast.NamedArg
 	// Create new argument slice in correct order
 	reorderedArgs := make([]ast.Expression, len(args))
 
-	// Handle named arguments
+	// Handle named arguments. Duplicate names (e.g. `add(a: 1, a: 2)`)
+	// used to silently overwrite the earlier slot and leave another slot
+	// nil, so codegen later barfed with "unsupported expression: <nil>".
+	// Flag the duplicate up-front with a useful message.
+	seen := make(map[string]bool, len(args))
+
 	for _, arg := range args {
+		if seen[arg.Name] {
+			return nil, fmt.Errorf("%w: duplicate named argument '%s' for function '%s'",
+				ErrUnknownParameterName, arg.Name, fnName)
+		}
+
+		seen[arg.Name] = true
+
 		pos, exists := paramPositions[arg.Name]
 		if !exists {
 			return nil, fmt.Errorf("%w '%s' for function '%s'; valid parameters: %s",

--- a/compiler/tests/unit/codegen/wave4_targeted_test.go
+++ b/compiler/tests/unit/codegen/wave4_targeted_test.go
@@ -137,6 +137,33 @@ fn main() -> int {
   print("name=${name} n=${n} b=${b}")
   0
 }`,
+		// mapList / filterList / foldList builtins — covers
+		// generateListBuilderLoop (shared by map+filter) and
+		// generateFoldListCall counted-loop.
+		"map_list": `
+fn main() -> int {
+  let xs = listAppend(listAppend(List(), 10), 20)
+  let doubled = mapList(xs, fn(x: int) => x * 2)
+  forEachList(doubled, print)
+  0
+}`,
+		"filter_list": `
+fn main() -> int {
+  let xs = listAppend(listAppend(listAppend(List(), 1), 2), 3)
+  let kept = filterList(xs, fn(x: int) => x > 1)
+  forEachList(kept, print)
+  0
+}`,
+		"fold_list": `
+fn main() -> int {
+  let xs = listAppend(listAppend(listAppend(List(), 1), 2), 3)
+  let total = foldList(xs, 0, fn(acc: int, x: int) => match acc + x {
+    Success v => v
+    Error e => acc
+  })
+  print(total)
+  0
+}`,
 	}
 
 	for name, src := range programs {


### PR DESCRIPTION
## Summary

Two independent additions on the same branch:

### Duplicate named arguments error cleanly (Osprey1)
Was crashing on nil — now produces a clean compile-time error.

### Add mapList / filterList / foldList builtins (Osprey2)
Lists had \`forEachList\` for side-effects but no pure transforms.
- \`mapList(xs, fn)\` — new list with fn applied per element
- \`filterList(xs, pred)\` — keeps elements where pred is truthy
- \`foldList(xs, init, fn)\` — left-fold

Lower to \`osprey_list_length\` / \`osprey_list_get\` counted loops. Map/filter use \`osprey_list_builder_*\`; fold accumulates in a stack alloca. Predicate compared against an int-typed zero so i1 bool works alongside i64.

## Test plan
- [x] \`mapList(xs, fn(x) => x * 2)\` returns the doubled list
- [x] \`filterList(xs, fn(x) => x > 1)\` keeps matching elements
- [x] \`foldList(xs, 0, fn(acc, x) => acc + x)\` reduces correctly
- [x] Duplicate named args case from Osprey1's fix unchanged
- [x] \`make test\` green, \`make lint\` clean