### PR TITLE
fix(errors): singular/plural in wrong-arg-count messages + Error formatting with NULL message

### DIFF
--- a/compiler/examples/failscompilation/length_wrong_args.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/length_wrong_args.ospo.expectedoutput
@@ -1,1 +1,1 @@
-line 5:17: length expects exactly 1 arguments (s), got 0
+line 5:17: length expects exactly 1 argument (s), got 0

--- a/compiler/examples/failscompilation/unsupported_unary_op.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/unsupported_unary_op.ospo.expectedoutput
@@ -1,1 +1,1 @@
-line 5:17: readFile expects exactly 1 arguments (filename), got 0
+line 5:17: readFile expects exactly 1 argument (filename), got 0

--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -345,14 +345,38 @@ func (g *LLVMGenerator) convertResultToString(
 		errorMsg = g.builder.NewExtractValue(result, 0)
 	}
 
-	// Format as "Error(message)" - handle different error message types
+	// Format as "Error(message)" - handle different error message types.
+	// When the runtime stores a NULL string in the Error payload
+	// (e.g. split returning Result<list, _>'s Error case stores nil),
+	// sprintf %s would print "(null)" — so substring's Error showed
+	// "Error((null))". Branch on null at runtime and fall back to a
+	// bare "Error" when the message pointer is NULL.
 	var errorStr value.Value
 	if structType.Fields[0] == types.I8Ptr {
-		// String error message - format as Error(message)
+		stringFormatBlock := g.function.NewBlock(fmt.Sprintf("error_str_fmt_%d", blockID))
+		nullErrorBlock := g.function.NewBlock(fmt.Sprintf("error_null_%d", blockID))
+		errorJoinBlock := g.function.NewBlock(fmt.Sprintf("error_join_%d", blockID))
+		isNull := g.builder.NewICmp(enum.IPredEQ, errorMsg, constant.NewNull(types.I8Ptr))
+		g.builder.NewCondBr(isNull, nullErrorBlock, stringFormatBlock)
+
+		// Non-null message → format with payload.
+		g.builder = stringFormatBlock
 		errorFormatStr := g.createGlobalString("Error(%s)")
 		errorBuffer := g.builder.NewCall(malloc, bufferSize)
 		g.builder.NewCall(sprintf, errorBuffer, errorFormatStr, errorMsg)
-		errorStr = errorBuffer
+		g.builder.NewBr(errorJoinBlock)
+
+		// Null message → bare "Error".
+		g.builder = nullErrorBlock
+		nullErrorStr := g.createGlobalString("Error")
+		g.builder.NewBr(errorJoinBlock)
+
+		g.builder = errorJoinBlock
+		errorStr = g.builder.NewPhi(
+			ir.NewIncoming(errorBuffer, stringFormatBlock),
+			ir.NewIncoming(nullErrorStr, nullErrorBlock),
+		)
+		errorBlock = errorJoinBlock
 	} else {
 		// Non-string error - just use "Error" for now
 		// TODO: Handle other error types properly

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -201,11 +201,21 @@ func WrapFunctionArgsWithPos(funcName string, expected int, actual int, pos any)
 		}
 
 		//nolint:err113 // Dynamic error needed for exact test format matching
-		return fmt.Errorf("line %d:%d: %s expects exactly %d arguments%s, got %d",
-			position.Line, position.Column, funcName, expected, paramNames, actual)
+		return fmt.Errorf("line %d:%d: %s expects exactly %d %s%s, got %d",
+			position.Line, position.Column, funcName, expected, pluralArgs(expected), paramNames, actual)
 	}
 
 	return WrapWrongArgCount(funcName, expected, actual)
+}
+
+// pluralArgs picks "argument" / "arguments" so error messages don't
+// emit "expects exactly 1 arguments".
+func pluralArgs(n int) string {
+	if n == 1 {
+		return "argument"
+	}
+
+	return "arguments"
 }
 
 // WrapUnsupportedExpression wraps errors for unsupported expressions
@@ -421,7 +431,8 @@ func WrapHTTPFunctionMissingNamedArg(funcName, argName string) error {
 
 // WrapWrongArgCount wraps wrong argument count errors
 func WrapWrongArgCount(funcName string, expected, actual int) error {
-	return fmt.Errorf("function %s expects %d arguments, got %d: %w", funcName, expected, actual, ErrWrongArgCount)
+	return fmt.Errorf("function %s expects %d %s, got %d: %w",
+		funcName, expected, pluralArgs(expected), actual, ErrWrongArgCount)
 }
 
 // WrapMissingArgument wraps missing argument errors

--- a/compiler/tests/unit/codegen/errors_test.go
+++ b/compiler/tests/unit/codegen/errors_test.go
@@ -515,17 +515,17 @@ func TestErrorWrappingWithoutPosition(t *testing.T) {
 		{
 			"WrapFunctionArgsWithPos nil position for print",
 			func() error { return codegen.WrapFunctionArgsWithPos("print", 1, 2, nil) },
-			"function print expects 1 arguments, got 2: wrong argument count",
+			"function print expects 1 argument, got 2: wrong argument count",
 		},
 		{
 			"WrapFunctionArgsWithPos nil position for length",
 			func() error { return codegen.WrapFunctionArgsWithPos("length", 1, 2, nil) },
-			"function length expects 1 arguments, got 2: wrong argument count",
+			"function length expects 1 argument, got 2: wrong argument count",
 		},
 		{
 			"WrapToStringWrongArgs",
 			func() error { return codegen.WrapToStringWrongArgs(2) },
-			"function toString expects 1 arguments, got 2: wrong argument count",
+			"function toString expects 1 argument, got 2: wrong argument count",
 		},
 		{
 			"WrapMissingArgument",

--- a/compiler/tests/unit/codegen/expression_generation_test.go
+++ b/compiler/tests/unit/codegen/expression_generation_test.go
@@ -166,13 +166,13 @@ func TestToStringConversions(t *testing.T) {
 			name:    "wrong arg count",
 			source:  `toString()`,
 			wantErr: true,
-			errMsg:  "function toString expects 1 arguments, got 0",
+			errMsg:  "function toString expects 1 argument, got 0",
 		},
 		{
 			name:    "too many args",
 			source:  `toString(1, 2)`,
 			wantErr: true,
-			errMsg:  "function toString expects 1 arguments, got 2",
+			errMsg:  "function toString expects 1 argument, got 2",
 		},
 	}
 
@@ -234,13 +234,13 @@ print(x)`,
 			name:    "print wrong args",
 			source:  `print()`,
 			wantErr: true,
-			errMsg:  "print expects exactly 1 arguments (value), got 0",
+			errMsg:  "print expects exactly 1 argument (value), got 0",
 		},
 		{
 			name:    "print too many args",
 			source:  `print(1, 2)`,
 			wantErr: true,
-			errMsg:  "print expects exactly 1 arguments (value), got 2",
+			errMsg:  "print expects exactly 1 argument (value), got 2",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Two error-message polish fixes bundled on the same branch:

### singular/plural in wrong-arg-count messages (Osprey1)
\"function print expects 1 arguments, got 0\" reads like a typo. Pick \"argument\" when expected==1 via a small \`pluralArgs\` helper. Touches both \`WrapWrongArgCount\` and \`WrapFunctionArgsWithPos\` so all wrong-arg-count error messages agree. Updated four test expectations (two .ospo.expectedoutput, two _test.go files) baked into the old wording.

### Result Error with NULL message prints \"Error\", not \"Error((null))\" (Osprey2)
\`\"hello\".substring(100, 200)\` printed \"Error((null))\" because the runtime stores a NULL string in the Error payload when substring's bounds check fails, and \`convertResultToString\` blindly formatted the i8* with sprintf %s. Branch on the runtime pointer: when the message is NULL fall back to a bare \"Error\" string; otherwise format as \`Error(message)\` as before.

## Test plan
- [x] \`"hello".substring(100, 200)\` now prints \"Error\" not \"Error((null))\"
- [x] \`print()\` (no args) now says \"expects 1 argument\" not \"1 arguments\"
- [x] \`make test\` green, \`make lint\` clean