### PR TITLE
fix(codegen): record/union equality now a clean error + makefile cleans test.log

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -157,6 +157,7 @@ clean:
 	rm -rf lib/
 	rm -rf outputs/
 	rm -rf internal/codegen/bin
+	rm -f test.log
 	find /tmp -name "*osprey*" -delete 2>/dev/null || true
 	find /tmp -name "*TestHTTP*" -delete 2>/dev/null || true
 	find /tmp -name "*TestManual*" -delete 2>/dev/null || true

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -76,9 +76,10 @@ var (
 
 	ErrUnsupportedCollectionType = errors.New("unsupported collection type for access")
 
-	ErrUnsupportedStatement = errors.New("unsupported statement")
-	ErrUndefinedVariable    = errors.New("undefined variable")
-	ErrUnsupportedBinaryOp  = errors.New("unsupported binary operator") // Alias for ErrUnsupportedBinaryOperator
+	ErrUnsupportedStatement     = errors.New("unsupported statement")
+	ErrUndefinedVariable        = errors.New("undefined variable")
+	ErrUnsupportedBinaryOp      = errors.New("unsupported binary operator") // Alias for ErrUnsupportedBinaryOperator
+	ErrStructComparisonNotImpl  = errors.New("structural comparison on records/unions is not yet implemented")
 
 	ErrMethodNotImpl         = errors.New("method not implemented")
 	ErrNoToStringForFunc     = errors.New("no toString implementation for function")
@@ -210,6 +211,15 @@ func WrapUndefinedVariableWithPos(varName string, pos any) error {
 // WrapUnsupportedBinaryOpWithPos wraps errors for unsupported binary operators
 func WrapUnsupportedBinaryOpWithPos(op string, pos any) error {
 	return WrapSimpleErrorWithPos(ErrUnsupportedBinaryOp, op, pos)
+}
+
+// WrapStructComparisonUnsupportedWithPos wraps the error fired when a record
+// or union value flows into `==` / `<` / etc. before structural comparison
+// is implemented. Used to swap llir's "invalid icmp operand type" panic for
+// an actionable compile error.
+func WrapStructComparisonUnsupportedWithPos(op, leftType, rightType string, pos any) error {
+	detail := fmt.Sprintf("%s on %s and %s", op, leftType, rightType)
+	return WrapSimpleErrorWithPos(ErrStructComparisonNotImpl, detail, pos)
 }
 
 // WrapVoidArithmeticWithPos wraps errors for arithmetic on void types

--- a/compiler/internal/codegen/expression_generation.go
+++ b/compiler/internal/codegen/expression_generation.go
@@ -1117,6 +1117,31 @@ func (g *LLVMGenerator) unwrapIfResult(val value.Value) value.Value {
 	return g.builder.NewExtractValue(val, 0)
 }
 
+// rejectStructComparison returns an error when one of the comparison operands
+// is a struct-shaped value (record, union variant). Without this guard llir's
+// NewICmp panics with "invalid icmp operand type" because it only accepts
+// integer, pointer or vector operands. Field-wise structural equality on
+// records is a future feature; for now we fail loud with a useful message.
+func rejectStructComparison(operator string, left, right value.Value, pos *ast.Position) error {
+	if !isStructShape(left.Type()) && !isStructShape(right.Type()) {
+		return nil
+	}
+	return WrapStructComparisonUnsupportedWithPos(operator, left.Type().String(), right.Type().String(), pos)
+}
+
+// isStructShape returns true for direct struct values and pointers-to-struct.
+// Both shapes blow up NewICmp.
+func isStructShape(t types.Type) bool {
+	if _, ok := t.(*types.StructType); ok {
+		return true
+	}
+	if pt, ok := t.(*types.PointerType); ok {
+		_, ok := pt.ElemType.(*types.StructType)
+		return ok
+	}
+	return false
+}
+
 // generateComparisonOperationWithPos generates LLVM comparison operations with position info.
 func (g *LLVMGenerator) generateComparisonOperationWithPos(
 	operator string, left, right value.Value, pos *ast.Position,
@@ -1125,6 +1150,15 @@ func (g *LLVMGenerator) generateComparisonOperationWithPos(
 	// This allows comparing arithmetic results: (10+5) < 20
 	left = g.unwrapIfResult(left)
 	right = g.unwrapIfResult(right)
+
+	// Reject struct / record / union comparison up-front with a clear error.
+	// llir's NewICmp panics on struct operands ("invalid icmp operand type")
+	// so a record like `Point{x:1,y:2} == Point{x:1,y:2}` used to crash the
+	// compiler. Field-wise structural equality is a future feature.
+	structErr := rejectStructComparison(operator, left, right, pos)
+	if structErr != nil {
+		return nil, structErr
+	}
 
 	// String comparison must use strcmp on byte contents — comparing the raw
 	// i8* pointers (which is what NewICmp does) is meaningless: == returns false


### PR DESCRIPTION
## Summary
Post-PR#73 leftovers:

- **codegen:** comparing two records or two unions used to crash llir with a panic; now emits a typed error pointing at the comparison.
- **makefile:** `make clean` also removes `test.log` alongside the rest of the build artefacts.

## Test plan
- [ ] `r1 == r2` between two records errors cleanly instead of llir panic
- [ ] `make clean` removes `test.log`