### PR TITLE
fix(errors): position-aware error for print(record) / unsupported print type

### DIFF
--- a/compiler/examples/failscompilation/print_record_unsupported.ospo
+++ b/compiler/examples/failscompilation/print_record_unsupported.ospo
@@ -1,0 +1,12 @@
+// print() on a record currently has no toString implementation. The error
+// must pin the offending print call's line/column and name the type so the
+// user can find and fix it; without positional info the bare "cannot
+// convert value for printing" was unactionable.
+
+type Pt = { x: int, y: int }
+
+fn main() -> int {
+    let p = Pt { x: 5, y: 10 }
+    print(p)
+    0
+}

--- a/compiler/examples/failscompilation/print_record_unsupported.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/print_record_unsupported.ospo.expectedoutput
@@ -1,0 +1,1 @@
+line 10:4: cannot convert value for printing: {x: int, y: int}

--- a/compiler/internal/codegen/core_functions.go
+++ b/compiler/internal/codegen/core_functions.go
@@ -431,7 +431,7 @@ func (g *LLVMGenerator) generatePrintCall(callExpr *ast.CallExpression) (value.V
 		return nil, err
 	}
 
-	stringArg, err := g.convertValueToStringForPrint(arg, inferredType)
+	stringArg, err := g.convertValueToStringForPrint(arg, inferredType, callExpr.Position)
 	if err != nil {
 		return nil, err
 	}
@@ -442,20 +442,26 @@ func (g *LLVMGenerator) generatePrintCall(callExpr *ast.CallExpression) (value.V
 }
 
 // convertValueToStringForPrint converts any value to a string for printing.
-func (g *LLVMGenerator) convertValueToStringForPrint(arg value.Value, inferredType Type) (value.Value, error) {
+// pos is the print call's source position, used to give the unsupported-type
+// error a usable line/column instead of a bare "cannot convert value".
+func (g *LLVMGenerator) convertValueToStringForPrint(
+	arg value.Value, inferredType Type, pos *ast.Position,
+) (value.Value, error) {
 	// Unit-returning calls (print, …) hand back nil. Reject up-front rather
 	// than dereferencing nil downstream in convertPrimitiveToString.
 	if arg == nil {
 		return nil, ErrPrintOnUnit
 	}
 	if g.isResultType(arg) {
-		return g.convertResultValueToString(arg)
+		return g.convertResultValueToString(arg, inferredType, pos)
 	}
-	return g.convertPrimitiveToString(arg, inferredType)
+	return g.convertPrimitiveToString(arg, inferredType, pos)
 }
 
 // convertResultValueToString handles Result type conversion to string.
-func (g *LLVMGenerator) convertResultValueToString(arg value.Value) (value.Value, error) {
+func (g *LLVMGenerator) convertResultValueToString(
+	arg value.Value, inferredType Type, pos *ast.Position,
+) (value.Value, error) {
 	if structType, ok := arg.Type().(*types.StructType); ok && len(structType.Fields) == ResultFieldCount {
 		return g.convertResultToString(arg, structType)
 	}
@@ -464,11 +470,13 @@ func (g *LLVMGenerator) convertResultValueToString(arg value.Value) (value.Value
 			return g.convertResultToString(arg, structType)
 		}
 	}
-	return nil, ErrPrintCannotConvert
+	return nil, WrapPrintCannotConvertWithPos(typeNameForError(inferredType, arg), pos)
 }
 
 // convertPrimitiveToString handles primitive type conversion to string.
-func (g *LLVMGenerator) convertPrimitiveToString(arg value.Value, inferredType Type) (value.Value, error) {
+func (g *LLVMGenerator) convertPrimitiveToString(
+	arg value.Value, inferredType Type, pos *ast.Position,
+) (value.Value, error) {
 	switch arg.Type().(type) {
 	case *types.PointerType:
 		return arg, nil
@@ -477,8 +485,40 @@ func (g *LLVMGenerator) convertPrimitiveToString(arg value.Value, inferredType T
 	case *types.FloatType:
 		return g.generateFloatToString(arg)
 	default:
-		return nil, ErrPrintCannotConvert
+		return nil, WrapPrintCannotConvertWithPos(typeNameForError(inferredType, arg), pos)
 	}
+}
+
+// typeNameForError picks the most descriptive type name for a "can't print
+// this" error. Falls back to the LLVM type string when the inferred type is
+// still an unresolved variable (so the user at least sees "{i64, i64}" or
+// similar instead of a bare "t12").
+func typeNameForError(inferredType Type, arg value.Value) string {
+	if inferredType != nil {
+		name := inferredType.String()
+		if name != "" && !looksLikeTypeVar(name) {
+			return name
+		}
+	}
+	if arg != nil && arg.Type() != nil {
+		return arg.Type().String()
+	}
+	return "<unknown>"
+}
+
+// looksLikeTypeVar reports whether a type-inference name is still an
+// unresolved variable (e.g. "t12") rather than a real type the user
+// would recognise.
+func looksLikeTypeVar(name string) bool {
+	if len(name) < 2 || name[0] != 't' {
+		return false
+	}
+	for _, c := range name[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // convertIntTypeToString handles int type conversion, distinguishing between bool and int.

--- a/compiler/internal/codegen/errors.go
+++ b/compiler/internal/codegen/errors.go
@@ -357,6 +357,14 @@ func WrapSimpleErrorWithPos(baseErr error, arg string, pos any) error {
 	return fmt.Errorf("%w: %s", baseErr, arg)
 }
 
+// WrapPrintCannotConvertWithPos wraps the print "cannot convert" error with
+// position + the source-level type name. Without this users got a bare
+// "cannot convert value for printing" with no clue which print or which
+// type — `print(somePoint)` failed with the same message as any other.
+func WrapPrintCannotConvertWithPos(typeName string, pos any) error {
+	return WrapSimpleErrorWithPos(ErrPrintCannotConvert, typeName, pos)
+}
+
 // Remaining wrapper functions that are NOT just one-line calls to WrapBuiltInFunctionWrongArgs
 
 // WrapHTTPStopServerUnknownNamedArg wraps errors for unknown named arguments in HTTP stop server

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -918,7 +918,7 @@ func (g *LLVMGenerator) generateInterpolatedString(interpStr *ast.InterpolatedSt
 				}
 
 				// Convert primitive to string using existing logic
-				stringVal, err = g.convertPrimitiveToString(exprVal, inferredType)
+				stringVal, err = g.convertPrimitiveToString(exprVal, inferredType, interpStr.Position)
 				if err != nil {
 					return nil, err
 				}

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -176,9 +177,19 @@ func NewOrderedRecordType(name string, fields map[string]Type, fieldOrder []stri
 }
 
 func (rt *RecordType) String() string {
-	fieldStrings := make([]string, 0, len(rt.fields))
-	for name, t := range rt.fields {
-		fieldStrings = append(fieldStrings, fmt.Sprintf("%s: %s", name, t.String()))
+	// Sort field names so the rendered type is deterministic — Go map
+	// iteration is randomised per run, which made error messages
+	// containing record types diff differently between CI and local
+	// (`{x: int, y: int}` vs `{y: int, x: int}`) and broke
+	// .expectedoutput fixtures non-deterministically.
+	names := make([]string, 0, len(rt.fields))
+	for name := range rt.fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	fieldStrings := make([]string, 0, len(names))
+	for _, name := range names {
+		fieldStrings = append(fieldStrings, fmt.Sprintf("%s: %s", name, rt.fields[name].String()))
 	}
 
 	return fmt.Sprintf("{%s}", strings.Join(fieldStrings, ", "))


### PR DESCRIPTION
## Summary
- \`print(p)\` on a record value previously failed with a bare \`cannot convert value for printing\` — no line/column, no hint about which type.
- \`convertPrimitiveToString\` / \`convertResultValueToString\` now thread the print call's source position and the inferred type name through to a new \`WrapPrintCannotConvertWithPos\`, so the error pins the offending call and names the type.
- \`typeNameForError\` prefers the inferred-type name and falls back to the LLVM type when the inferer left an unresolved variable (\`t12\`).
- String-interpolation site (\`\${p}\`) gets the same wrapping via \`interpStr.Position\`.

Before: \`Execution failed: failed to generate LLVM IR: cannot convert value for printing\`
After:  \`Execution failed: failed to generate LLVM IR: line 10:4: cannot convert value for printing: {x: int, y: int}\`

## Test plan
- [x] New failscompilation fixture \`print_record_unsupported.ospo\` pins the line/column + type-name in the expected output.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)