### PR TITLE
fix(codegen): mapSet/mapGet/mapContains/mapRemove reject int/bool keys (was SIGSEGV)

### DIFF
--- a/compiler/examples/failscompilation/map_int_key_segfault.ospo
+++ b/compiler/examples/failscompilation/map_int_key_segfault.ospo
@@ -1,0 +1,8 @@
+// This should fail compilation: Map() defaults to string keys, so int keys
+// would SIGSEGV at runtime when hash_string dereferences the int-bit-pattern
+// as a char*. Until typed Map constructors land, mapSet must reject non-string keys.
+
+fn main() -> int {
+  let m = mapSet(Map(), 1, "one")
+  0
+}

--- a/compiler/examples/failscompilation/map_int_key_segfault.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/map_int_key_segfault.ospo.expectedoutput
@@ -1,0 +1,1 @@
+mapSet: mapSet/mapGet/mapContains/mapRemove require string keys (Map() defaults to string keys); int/bool/float keys would SIGSEGV at runtime

--- a/compiler/internal/codegen/collection_codegen.go
+++ b/compiler/internal/codegen/collection_codegen.go
@@ -42,7 +42,27 @@ var (
 	errCollectionArgCount   = errors.New("wrong argument count")
 	errCollectionExternMiss = errors.New("collection extern not declared")
 	errForEachListSecondArg = errors.New("forEachList: second argument must be a function name")
+	// errMapNonStringKey fires when mapSet/mapGet/mapContains/mapRemove
+	// receive a non-pointer key (int/bool/float). Map() currently always
+	// emits OSPREY_KEY_STRING, so the runtime would dereference the
+	// int-bit-pattern as a char* in hash_string and SIGSEGV. Until typed
+	// Map constructors land, surface the limitation at compile time.
+	errMapNonStringKey = errors.New(
+		"mapSet/mapGet/mapContains/mapRemove require string keys (Map() defaults to string keys); " +
+			"int/bool/float keys would SIGSEGV at runtime")
 )
+
+// rejectNonStringMapKey errors when k's LLVM type is a non-pointer
+// (int / bool / float). Map() defaults to OSPREY_KEY_STRING and the
+// runtime's hash_string would dereference the key's int-bit-pattern as a
+// char* and SIGSEGV. Pointer-typed keys (strings, records bit-cast to
+// i8*) flow through unchanged.
+func rejectNonStringMapKey(k value.Value, op string) error {
+	if _, isPtr := k.Type().(*types.PointerType); isPtr {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", op, errMapNonStringKey)
+}
 
 // ensureCollectionExtern declares an osprey_list_* / osprey_map_* function
 // once and caches it. The codegen helpers below all funnel through here.
@@ -380,6 +400,10 @@ func (g *LLVMGenerator) generateMapContainsCall(callExpr *ast.CallExpression) (v
 	if err != nil {
 		return nil, err
 	}
+	keyErr := rejectNonStringMapKey(k, "mapContains")
+	if keyErr != nil {
+		return nil, keyErr
+	}
 	res := g.builder.NewCall(g.functions["osprey_map_contains"], m, g.boxToI64(k))
 	return g.builder.NewICmp(enum.IPredNE, res, constant.NewInt(types.I32, 0)), nil
 }
@@ -401,6 +425,10 @@ func (g *LLVMGenerator) generateMapGetCall(callExpr *ast.CallExpression) (value.
 	k, err := g.generateExpression(callExpr.Arguments[1])
 	if err != nil {
 		return nil, err
+	}
+	keyErr := rejectNonStringMapKey(k, "mapGet")
+	if keyErr != nil {
+		return nil, keyErr
 	}
 	boxedKey := g.boxToI64(k)
 	contains := g.builder.NewCall(g.functions["osprey_map_contains"], m, boxedKey)
@@ -435,6 +463,10 @@ func (g *LLVMGenerator) generateMapSetCall(callExpr *ast.CallExpression) (value.
 	if err != nil {
 		return nil, err
 	}
+	keyErr := rejectNonStringMapKey(k, "mapSet")
+	if keyErr != nil {
+		return nil, keyErr
+	}
 	v, err := g.generateExpression(callExpr.Arguments[2])
 	if err != nil {
 		return nil, err
@@ -454,6 +486,10 @@ func (g *LLVMGenerator) generateMapRemoveCall(callExpr *ast.CallExpression) (val
 	k, err := g.generateExpression(callExpr.Arguments[1])
 	if err != nil {
 		return nil, err
+	}
+	keyErr := rejectNonStringMapKey(k, "mapRemove")
+	if keyErr != nil {
+		return nil, keyErr
 	}
 	return g.builder.NewCall(g.functions["osprey_map_remove"], m, g.boxToI64(k)), nil
 }


### PR DESCRIPTION
## Summary

\`Map()\` always emits \`OSPREY_KEY_STRING\` so the HAMT's \`hash_string\`
treats the key as a \`char*\`. Passing a non-string key like
\`mapSet(Map(), 1, "one")\` derefs the int-bit-pattern as a pointer and
SIGSEGVs at runtime.

Convert the silent crash into a compile-time error in \`mapSet\`,
\`mapGet\`, \`mapContains\`, and \`mapRemove\`. Pointer-typed keys (strings,
records bit-cast to \`i8*\`) continue through unchanged.

## Test plan
- [x] new failscompilation example: \`examples/failscompilation/map_int_key_segfault.ospo\`
- [x] string-keyed maps still work end-to-end
- [x] \`make lint\` clean, \`go test ./tests/integration\` green

## Follow-up
A complete fix needs typed Map constructors (\`MapInt()\`, \`MapBool()\`) or
deferred key-type resolution from the first set — both out-of-scope for
this PR. This stops the segfault and makes the limitation discoverable.