### PR TITLE
fix(cli): stream stdin/stdout for --run so interactive TUIs work

### DIFF
--- a/compiler/internal/cli/cli.go
+++ b/compiler/internal/cli/cli.go
@@ -258,8 +258,13 @@ func runRunProgram(source string, quiet bool) CommandResult {
 		fmt.Fprintf(os.Stderr, "Starting compilation...\n")
 	}
 
-	// CAPTURE PROGRAM OUTPUT instead of outputting directly to terminal!
-	programOutput, err := codegen.CompileAndCapture(source)
+	// STREAM the program directly to the terminal (stdin/stdout/stderr wired
+	// through) rather than capturing. Interactive programs - raw-mode TUIs that
+	// read keystrokes via termReadKey, or input() line readers - need a live
+	// stdin and incremental output. Capturing would feed EOF on the first read
+	// and buffer the whole screen until exit. Compilation diagnostics already go
+	// to stderr above, so stdout stays clean.
+	err := codegen.CompileAndRun(source)
 	if err != nil {
 		// ALWAYS show compilation errors regardless of quiet flag
 		fmt.Fprintf(os.Stderr, "Compilation failed\n")
@@ -274,10 +279,7 @@ func runRunProgram(source string, quiet bool) CommandResult {
 		fmt.Fprintf(os.Stderr, "Compilation completed successfully\n")
 	}
 
-	return CommandResult{
-		Output:  programOutput, // ✅ RETURN THE ACTUAL PROGRAM OUTPUT!
-		Success: true,
-	}
+	return CommandResult{Success: true}
 }
 
 func runShowSymbols(source, _ string) CommandResult {
@@ -1121,8 +1123,10 @@ func runRunProgramWithSecurity(source string, quiet bool, security *SecurityConf
 	// Convert CLI security config to codegen security config
 	codegenSecurity := convertToCodegenSecurity(security)
 
-	// CAPTURE PROGRAM OUTPUT instead of outputting directly to terminal!
-	programOutput, err := codegen.CompileAndCaptureWithSecurity(source, codegenSecurity)
+	// STREAM the program directly to the terminal (see runRunProgram) so
+	// interactive raw-mode TUIs and input() readers get a live stdin and
+	// incremental output instead of a captured, EOF-on-first-read buffer.
+	err := codegen.CompileAndRunWithSecurity(source, codegenSecurity)
 	if err != nil {
 		// ALWAYS show compilation errors regardless of quiet flag
 		fmt.Fprintf(os.Stderr, "Compilation failed\n")
@@ -1137,10 +1141,7 @@ func runRunProgramWithSecurity(source string, quiet bool, security *SecurityConf
 		fmt.Fprintf(os.Stderr, "Compilation completed successfully\n")
 	}
 
-	return CommandResult{
-		Output:  programOutput, // ✅ RETURN THE ACTUAL PROGRAM OUTPUT!
-		Success: true,
-	}
+	return CommandResult{Success: true}
 }
 
 func runShowSymbolsWithSecurity(source, filename string, _ *SecurityConfig) CommandResult {

--- a/compiler/internal/codegen/jit_executor.go
+++ b/compiler/internal/codegen/jit_executor.go
@@ -272,6 +272,11 @@ func (j *JITExecutor) linkExecutable(linkArgs []string) error {
 func (j *JITExecutor) executeProgram(exeFile string) error {
 	// #nosec G204 - exeFile is created in controlled temp directory
 	runCmd := exec.CommandContext(context.Background(), exeFile)
+	// Wire stdin through so interactive programs (raw-mode TUIs reading keys via
+	// termReadKey, line input via input()) receive keystrokes. Without this Go
+	// connects the child's stdin to /dev/null, so the first read hits EOF and an
+	// interactive loop exits immediately.
+	runCmd.Stdin = os.Stdin
 	runCmd.Stdout = os.Stdout
 	runCmd.Stderr = os.Stderr
 


### PR DESCRIPTION
## Interactive `--run` was broken for TUIs (instant quit)

`osprey <file> --run` ran the compiled program through the **capture** path
(`runRunProgram → CompileAndCapture → executeProgramWithCapture`, i.e.
`exec.Cmd.Output()`). That path never wired the child's **stdin**, so Go pointed
it at `/dev/null`: the first `termReadKey()` / `input()` read hit EOF and any
interactive loop exited immediately. It also buffered stdout until exit, so a
TUI's frames only appeared *after* the program had already quit.

That's exactly the reported symptom — `examples/tui/api_browser.osp` printed one
frame and then `Goodbye!` without accepting a single keystroke.

### Fix
Switch CLI run mode to the **streaming** path (`CompileAndRun → executeProgram`),
which now wires `Stdin`, `Stdout`, `Stderr` straight through. `executeProgram`
already streamed stdout/stderr; it was only missing `Stdin`, now added.

- Non-interactive use is unchanged: compilation diagnostics stay on stderr, and
  run-mode tests still see an empty `CommandResult.Output`.
- The integration harness is unaffected — it drives programs via
  `captureJITOutput → CompileAndRunJIT` (os.Stdout redirection), not the CLI
  capture functions.

### Verification
- **Real PTY E2E** (scripted keystrokes Down/Down/Enter/back/Up/q): the selection
  arrow moves across repos (`osprey → llvm → antlr`), Enter opens the detail
  view (antlr description renders), and the app exits **only** on `q` — never
  instantly on startup.
- `make test` (lint + integration + unit + coverage) and run-mode unit tests all
  pass.
