### PR TITLE
feat: HTTPS client + algebraic-effects TUI, with Result type-inference/codegen fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,10 @@
     "//2": "so the Make Targets panel shows ONLY root targets - not the compiler/",
     "//3": "sub-makefile or its parsed variables.",
     "makefile.makefilePath": "Makefile",
-    "makefile.makeDirectory": "."
+    "makefile.makeDirectory": ".",
+    "//4": "Use the freshly-built dev compiler for LSP diagnostics so the editor",
+    "//5": "matches `make`/`./bin/osprey` instead of a stale global `osprey`. The",
+    "//6": "server execs this path verbatim (no variable substitution), so it is",
+    "//7": "absolute. Run `make build` to refresh it; see `make vsix` for packaging.",
+    "osprey.server.compilerPath": "/Users/christianfindlay/Documents/Code/osprey/compiler/bin/osprey"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
         "titleBar.inactiveBackground": "#2d4e2d",
         "titleBar.inactiveForeground": "#ffffffcc",
         "activityBar.background": "#3d683d"
-    }
+    },
+    "//": "Single Makefile entry point: the root Makefile is the public surface,",
+    "//2": "so the Make Targets panel shows ONLY root targets - not the compiler/",
+    "//3": "sub-makefile or its parsed variables.",
+    "makefile.makefilePath": "Makefile",
+    "makefile.makeDirectory": "."
 }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Primary language: Go (compiler/), with TypeScript sub-projects
 # =============================================================================
 
-.PHONY: build test lint fmt clean ci setup ratchet
+.PHONY: build tui test lint fmt clean ci setup ratchet
 
 # ---------------------------------------------------------------------------
 # OS Detection
@@ -48,6 +48,13 @@ build:
 	@echo "==> Building..."
 	cd compiler && $(MAKE) build
 	cd vscode-extension && npm run compile
+
+## tui: Rebuild the compiler and launch the interactive TUI demo (live GitHub
+##      API browser). Runs in the current terminal so the raw-mode key reader
+##      gets a real stdin.
+tui:
+	@echo "==> Building compiler + launching TUI..."
+	cd compiler && $(MAKE) tui
 
 ## test: Fail-fast tests + coverage + per-project threshold enforcement.
 ##       See REPO-STANDARDS-SPEC [TEST-RULES] and [COVERAGE-THRESHOLDS-JSON].

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,8 @@ vsix:
 	$(MAKE) _vsix_uninstall
 	@echo "==> [vsix] extension build"
 	$(MAKE) _vsix_build
+	@echo "==> [vsix] bundle freshly-built compiler"
+	$(MAKE) _vsix_bundle
 	@echo "==> [vsix] package"
 	$(MAKE) _vsix_package
 	@echo "==> [vsix] install (all profiles)"
@@ -277,6 +279,20 @@ _vsix_uninstall:
 
 _vsix_build:
 	cd $(EXT_DIR) && npm run compile
+
+# Stage the freshly-built compiler where the extension's resolveBundledCompiler
+# looks for it (bin/<os>-<arch>/osprey), so the packaged VSIX runs LSP
+# diagnostics against THIS compiler instead of a stale global `osprey`. The
+# platform string mirrors shipwrightPlatform() in client/src/extension.ts.
+# bin/ is not in .vscodeignore, so vsce includes it in the package.
+_vsix_bundle:
+	@OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	case "$$OS" in darwin) OS=darwin;; linux) OS=linux;; *) OS=win32;; esac; \
+	ARCH=$$(uname -m); case "$$ARCH" in arm64|aarch64) ARCH=arm64;; *) ARCH=x64;; esac; \
+	DEST="$(EXT_DIR)/bin/$$OS-$$ARCH"; \
+	mkdir -p "$$DEST"; \
+	cp compiler/bin/osprey "$$DEST/osprey"; \
+	echo "  bundled compiler -> $$DEST/osprey ($$($$DEST/osprey --version 2>/dev/null | head -1))"
 
 _vsix_package:
 	cd $(EXT_DIR) && npm run package

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-no-lint build-windows-core clean test test-runtime regenerate-parser install-deps install uninstall lint lint-fix lint-install c-lint c-test fiber-runtime http-runtime websocket-runtime system-runtime rust-interop run
+.PHONY: build build-no-lint build-windows-core clean test test-runtime regenerate-parser install-deps install uninstall lint lint-fix lint-install c-lint c-test fiber-runtime http-runtime websocket-runtime system-runtime rust-interop run tui
 
 # Version stamping — [SWR-VERSION-BUILD-STAMPING].
 # Source default is the 0.0.0-dev placeholder; release builds pass VERSION=<tag> in.
@@ -293,3 +293,10 @@ regenerate-parser:
 run:
 	@if [ -z "$(FILE)" ]; then echo "Usage: make run FILE=<path>"; exit 1; fi
 	go run cmd/osprey/main.go $(FILE)
+
+# Rebuild the compiler and launch the interactive TUI demo (live GitHub API
+# browser). Runs the built binary directly so stdin stays a real terminal -
+# the raw-mode key reader needs it.
+tui: build
+	@echo "🚀 Launching TUI: examples/tui/api_browser.osp"
+	./bin/osprey$(EXE) examples/tui/api_browser.osp --run

--- a/compiler/examples/failscompilation/union_type_mismatch.ospo.expectedoutput
+++ b/compiler/examples/failscompilation/union_type_mismatch.ospo.expectedoutput
@@ -1,1 +1,1 @@
-function call type mismatch: actual=(Shape) -> string, expected=(Color) -> t2: parameter 0 unification failed: Shape vs Color: type mismatch: Shape != Color
+function call type mismatch: actual=(Shape) -> string, expected=(Color) -> t1: parameter 0 unification failed: Shape vs Color: type mismatch: Shape != Color

--- a/compiler/examples/tui/api_browser.osp
+++ b/compiler/examples/tui/api_browser.osp
@@ -10,13 +10,16 @@
 //  (https://api.github.com/users/<user>/repos) over HTTPS, parses the JSON,
 //  and renders a colored, arrow-key-navigable list on the alternate screen.
 //
-//  Everything is expressions: each screen is a STRING built by composing pure
-//  functions, then handed to a single print. The render loop is recursion
-//  (Osprey has no loop keyword) - each keystroke tail-calls the next frame.
+//  Expression-only: there are NO local bindings. Every screen is a string
+//  built by composing pure functions and concatenating with `+`. A value that
+//  more than one expression needs (the http client, a response handle, a row's
+//  columns) rides as a function PARAMETER instead of a local. Terminal control
+//  is just text - the clear/show-cursor ANSI escapes are folded straight into
+//  the printed string, so only the genuine tcsetattr syscall (termRawMode)
+//  stays a call. The loop is recursion: each keystroke tail-calls the next frame.
 //  Builtins exercised: httpCreateClient/httpGetResponse/httpResponseBody
 //  [HTTP-RESPONSE-HANDLE], jsonParse/jsonGet/jsonLength [BUILTIN-JSON],
-//  termRawMode/termReadKey/termClear/termHideCursor/termShowCursor
-//  [BUILTIN-TERM], \e ANSI escapes.
+//  termRawMode/termReadKey [BUILTIN-TERM], \e ANSI escapes.
 // ============================================================================
 
 // Which GitHub account's public repositories to browse.
@@ -33,7 +36,7 @@ fn invert(s: string) -> string = "\e[7m${s}\e[0m"
 
 fn rule() -> string = dim("  ==================================================")
 
-// ---- small Result-unwrapping helpers (one expression each) ------------------
+// ---- Result-unwrapping helpers (one expression each) ------------------------
 fn pad(s: string, n: int) -> string = match padEnd(s, n, " ") {
     Success { value } => value
     Error { message } => s
@@ -57,47 +60,42 @@ fn inc(x: int) -> int = match x + 1 {
 }
 
 // ---- list rendering: each row is a string, the list folds via recursion -----
-fn rowText(doc: int, i: int, sel: int) -> string = {
-    let name = field(doc: doc, path: "[${i}].name")
-    let stars = field(doc: doc, path: "[${i}].stargazers_count")
-    let lang = field(doc: doc, path: "[${i}].language")
-    let nameP = pad(s: name, n: 20)
-    let starP = pad(s: stars, n: 7)
-    let row = "${nameP}* ${starP}${lang}"
-    match i == sel {
-        true => {
-            let hl = invert(" ${row} ")
-            "  ${cyan(">")} ${hl}"
-        }
-        false => {
-            let st = yellow("* ${starP}")
-            "    ${bold(nameP)}${st}${dim(lang)}"
-        }
-    }
+// rowLine takes the three already-extracted columns as parameters (computed
+// once by rowText) so neither branch recomputes them and no local is needed.
+fn rowLine(i: int, sel: int, nameP: string, starP: string, lang: string) -> string = match i == sel {
+    true => "  " + cyan(">") + " " + invert(" " + nameP + "* " + starP + lang + " ")
+    false => "    " + bold(nameP) + yellow("* " + starP) + dim(lang)
 }
 
+fn rowText(doc: int, i: int, sel: int) -> string = rowLine(
+    i: i,
+    sel: sel,
+    nameP: pad(s: field(doc: doc, path: "[${i}].name"), n: 20),
+    starP: pad(s: field(doc: doc, path: "[${i}].stargazers_count"), n: 7),
+    lang: field(doc: doc, path: "[${i}].language"))
+
 fn rowsText(doc: int, i: int, sel: int, n: int) -> string = match i < n {
-    true => "${rowText(doc: doc, i: i, sel: sel)}\n${rowsText(doc: doc, i: inc(i), sel: sel, n: n)}"
+    true => rowText(doc: doc, i: i, sel: sel) + "\n" + rowsText(doc: doc, i: inc(i), sel: sel, n: n)
     false => ""
 }
 
-fn screenText(doc: int, sel: int, n: int) -> string = {
-    let title = bold(cyan("  OSPREY  -  GitHub Repos: ${githubUser()}  (live API)"))
-    let hint = dim("  up/down or j/k move    enter details    q quit")
-    let rows = rowsText(doc: doc, i: 0, sel: sel, n: n)
-    "\n${title}\n${rule()}\n\n${rows}\n${rule()}\n${hint}"
-}
+fn screenText(doc: int, sel: int, n: int) -> string =
+    "\n" +
+    bold(cyan("  OSPREY  -  GitHub Repos: ${githubUser()}  (live API)")) + "\n" +
+    rule() + "\n\n" +
+    rowsText(doc: doc, i: 0, sel: sel, n: n) + "\n" +
+    rule() + "\n" +
+    dim("  up/down or j/k move    enter details    q quit")
 
-fn detailText(doc: int, sel: int) -> string = {
-    let name = field(doc: doc, path: "[${sel}].name")
-    let stars = field(doc: doc, path: "[${sel}].stargazers_count")
-    let lang = field(doc: doc, path: "[${sel}].language")
-    let desc = field(doc: doc, path: "[${sel}].description")
-    let top = magenta("  +-- Repository ------------------------------+")
-    let bot = magenta("  +--------------------------------------------+")
-    let nameLine = bold(green(name))
-    "\n${top}\n  |\n  |   ${nameLine}\n  |   ${yellow("Stars")} : ${stars}\n  |   ${cyan("Lang ")} : ${lang}\n  |   ${dim("About")} : ${desc}\n  |\n${bot}\n${dim("  press any key to go back")}"
-}
+fn detailText(doc: int, sel: int) -> string =
+    "\n" +
+    magenta("  +-- Repository ------------------------------+") + "\n  |\n  |   " +
+    bold(green(field(doc: doc, path: "[${sel}].name"))) + "\n  |   " +
+    yellow("Stars") + " : " + field(doc: doc, path: "[${sel}].stargazers_count") + "\n  |   " +
+    cyan("Lang ") + " : " + field(doc: doc, path: "[${sel}].language") + "\n  |   " +
+    dim("About") + " : " + field(doc: doc, path: "[${sel}].description") + "\n  |\n" +
+    magenta("  +--------------------------------------------+") + "\n" +
+    dim("  press any key to go back")
 
 // ---- selection movement (pure int -> int) -----------------------------------
 fn moveUp(sel: int) -> int = match sel > 0 {
@@ -110,27 +108,26 @@ fn moveDown(sel: int, n: int) -> int = match sel < dec(n) {
     false => sel
 }
 
-// ---- screens: draw is the ONLY place that touches the terminal --------------
-fn drawScreen(doc: int, sel: int, n: int) -> Unit = {
-    let cleared = termClear()
-    print(screenText(doc: doc, sel: sel, n: n))
-}
+// ---- screens: terminal control is just text -------------------------------
+// \e[2J\e[H clears + homes the cursor; \e[?25h shows it. Folding these escapes
+// into the printed string means a "clear" is a character, not a side effect.
+fn drawScreen(doc: int, sel: int, n: int) -> Unit = print("\e[2J\e[H" + screenText(doc: doc, sel: sel, n: n))
 
 fn detailView(doc: int, sel: int) -> Unit = {
-    let cleared = termClear()
-    let shown = print(detailText(doc: doc, sel: sel))
+    print("\e[2J\e[H" + detailText(doc: doc, sel: sel))
     match termReadKey() { _ => print("") }
 }
 
+// termRawMode is a real tcsetattr syscall (it also toggles the alternate
+// screen), so it stays a call; the show-cursor escape folds into the farewell.
 fn endApp() -> Unit = {
-    let raw = termRawMode(0)
-    let cursor = termShowCursor()
-    print(green("  Goodbye!"))
+    termRawMode(0)
+    print("\e[?25h" + green("  Goodbye!"))
 }
 
 // ---- the render / input loop (recursion stands in for a while-loop) ---------
 fn uiLoop(doc: int, sel: int, n: int) -> Unit = {
-    let drawn = drawScreen(doc: doc, sel: sel, n: n)
+    drawScreen(doc: doc, sel: sel, n: n)
     match termReadKey() {
         Success { value } => handleKey(doc: doc, sel: sel, n: n, key: value)
         Error { message } => endApp()
@@ -149,41 +146,41 @@ fn handleKey(doc: int, sel: int, n: int, key: string) -> Unit = match key {
 }
 
 fn openDetail(doc: int, sel: int, n: int) -> Unit = {
-    let shown = detailView(doc: doc, sel: sel)
+    detailView(doc: doc, sel: sel)
     uiLoop(doc: doc, sel: sel, n: n)
 }
 
-// startUi parses the fetched JSON, enters raw mode + alternate screen, and runs
+// startUi enters raw mode + the alternate screen, hides the cursor, and runs
 // the interactive loop over the live repository list.
 fn startUi(bodyText: string) -> Unit = match jsonParse(bodyText) {
     Success { value } => {
-        let n = jsonLength(value, "")
-        let raw = termRawMode(1)
-        let hidden = termHideCursor()
-        uiLoop(doc: value, sel: 0, n: n)
+        termRawMode(1)
+        termHideCursor()
+        uiLoop(doc: value, sel: 0, n: jsonLength(value, ""))
     }
     Error { message } => print("JSON parse failed")
 }
 
-fn run() -> Unit = {
-    // Real, live HTTPS call to the GitHub REST API. GitHub requires a
-    // User-Agent header and rejects requests without one.
-    let clientId = httpCreateClient("https://api.github.com", 10000)
-    let path = "/users/${githubUser()}/repos?per_page=30&sort=updated"
-    let headers = "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n"
-    let resp = httpGetResponse(clientId, path, headers)
-    match resp {
-        Success { value } => {
-            let body = httpResponseBody(value)
-            match body {
-                Success { text } => startUi(text)
-                Error { message } => print("Could not read response body")
-            }
-            let freed = httpResponseFree(value)
-        }
+// ---- HTTP plumbing ----------------------------------------------------------
+// The client id and the response handle are each needed twice (request then
+// close; read then free), so they travel as parameters rather than locals.
+fn run() -> Unit = browse(httpCreateClient("https://api.github.com", 10000))
+
+fn browse(clientId: int) -> Unit = {
+    // GitHub requires a User-Agent header and rejects requests without one.
+    match httpGetResponse(clientId, "/users/${githubUser()}/repos?per_page=30&sort=updated", "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n") {
+        Success { value } => useResponse(value)
         Error { message } => print("Request failed: ${message}")
     }
-    let closed = httpCloseClient(clientId)
+    httpCloseClient(clientId)
+}
+
+fn useResponse(resp: int) -> Unit = {
+    match httpResponseBody(resp) {
+        Success { text } => startUi(text)
+        Error { message } => print("Could not read response body")
+    }
+    httpResponseFree(resp)
 }
 
 run()

--- a/compiler/examples/tui/api_browser.osp
+++ b/compiler/examples/tui/api_browser.osp
@@ -9,8 +9,10 @@
 //  It fetches live public repositories from the GitHub REST API
 //  (https://api.github.com/users/<user>/repos) over HTTPS, parses the JSON,
 //  and renders a colored, arrow-key-navigable list on the alternate screen.
-//  The render loop is expressed as recursion (Osprey has no loop keyword) -
-//  each keystroke tail-calls the next frame.
+//
+//  Everything is expressions: each screen is a STRING built by composing pure
+//  functions, then handed to a single print. The render loop is recursion
+//  (Osprey has no loop keyword) - each keystroke tail-calls the next frame.
 //  Builtins exercised: httpCreateClient/httpGetResponse/httpResponseBody
 //  [HTTP-RESPONSE-HANDLE], jsonParse/jsonGet/jsonLength [BUILTIN-JSON],
 //  termRawMode/termReadKey/termClear/termHideCursor/termShowCursor
@@ -29,69 +31,64 @@ fn bold(s: string) -> string = "\e[1m${s}\e[0m"
 fn dim(s: string) -> string = "\e[2m${s}\e[0m"
 fn invert(s: string) -> string = "\e[7m${s}\e[0m"
 
-// ---- small Result-unwrapping helpers ---------------------------------------
-fn pad(s: string, n: int) -> string = {
-    let r = padEnd(s, n, " ")
-    match r {
-        Success { value } => value
-        Error { message } => s
-    }
+fn rule() -> string = dim("  ==================================================")
+
+// ---- small Result-unwrapping helpers (one expression each) ------------------
+fn pad(s: string, n: int) -> string = match padEnd(s, n, " ") {
+    Success { value } => value
+    Error { message } => s
 }
 
-fn field(doc: int, path: string) -> string = {
-    let r = jsonGet(doc, path)
-    match r {
-        Success { value } => value
-        Error { message } => "?"
-    }
+fn field(doc: int, path: string) -> string = match jsonGet(doc, path) {
+    Success { value } => value
+    Error { message } => "?"
 }
 
-// ---- list rendering --------------------------------------------------------
-fn renderItem(doc: int, i: int, sel: int, n: int) -> Unit = {
-    match i < n {
+// Checked arithmetic (+/-) returns Result<int, MathError>; unwrap with the
+// argument itself as the fallback so callers get a plain int.
+fn dec(x: int) -> int = match x - 1 {
+    Success { value } => value
+    Error { message } => x
+}
+
+fn inc(x: int) -> int = match x + 1 {
+    Success { value } => value
+    Error { message } => x
+}
+
+// ---- list rendering: each row is a string, the list folds via recursion -----
+fn rowText(doc: int, i: int, sel: int) -> string = {
+    let name = field(doc: doc, path: "[${i}].name")
+    let stars = field(doc: doc, path: "[${i}].stargazers_count")
+    let lang = field(doc: doc, path: "[${i}].language")
+    let nameP = pad(s: name, n: 20)
+    let starP = pad(s: stars, n: 7)
+    let row = "${nameP}* ${starP}${lang}"
+    match i == sel {
         true => {
-            let name = field(doc: doc, path: "[${i}].name")
-            let stars = field(doc: doc, path: "[${i}].stargazers_count")
-            let lang = field(doc: doc, path: "[${i}].language")
-            let nameP = pad(s: name, n: 20)
-            let starP = pad(s: stars, n: 7)
-            let row = "${nameP}* ${starP}${lang}"
-            let selected = i == sel
-            match selected {
-                true => {
-                    let arrow = cyan(">")
-                    let hl = invert(" ${row} ")
-                    print("  ${arrow} ${hl}")
-                }
-                false => {
-                    let nm = bold(nameP)
-                    let st = yellow("* ${starP}")
-                    let lg = dim(lang)
-                    print("    ${nm}${st}${lg}")
-                }
-            }
-            renderItem(doc: doc, i: i + 1, sel: sel, n: n)
+            let hl = invert(" ${row} ")
+            "  ${cyan(">")} ${hl}"
         }
-        false => print("")
+        false => {
+            let st = yellow("* ${starP}")
+            "    ${bold(nameP)}${st}${dim(lang)}"
+        }
     }
 }
 
-fn drawScreen(doc: int, sel: int, n: int) -> Unit = {
-    let cleared = termClear()
-    let title = bold(cyan("  OSPREY  -  GitHub Repos: ${githubUser()}  (live API)"))
-    let rule = dim("  ==================================================")
-    let hint = dim("  up/down or j/k move    enter details    q quit")
-    print("")
-    print(title)
-    print(rule)
-    print("")
-    renderItem(doc: doc, i: 0, sel: sel, n: n)
-    print(rule)
-    print(hint)
+fn rowsText(doc: int, i: int, sel: int, n: int) -> string = match i < n {
+    true => "${rowText(doc: doc, i: i, sel: sel)}\n${rowsText(doc: doc, i: inc(i), sel: sel, n: n)}"
+    false => ""
 }
 
-fn detailView(doc: int, sel: int) -> Unit = {
-    let cleared = termClear()
+fn screenText(doc: int, sel: int, n: int) -> string = {
+    let title = bold(cyan("  OSPREY  -  GitHub Repos: ${githubUser()}  (live API)"))
+    let hint = dim("  up/down or j/k move    enter details    q quit")
+    let rows = rowsText(doc: doc, i: 0, sel: sel, n: n)
+    "\n${title}\n${rule()}\n\n${rows}\n${rule()}\n${hint}"
+}
+
+fn detailText(doc: int, sel: int) -> string = {
     let name = field(doc: doc, path: "[${sel}].name")
     let stars = field(doc: doc, path: "[${sel}].stargazers_count")
     let lang = field(doc: doc, path: "[${sel}].language")
@@ -99,87 +96,56 @@ fn detailView(doc: int, sel: int) -> Unit = {
     let top = magenta("  +-- Repository ------------------------------+")
     let bot = magenta("  +--------------------------------------------+")
     let nameLine = bold(green(name))
-    let starsLabel = yellow("Stars")
-    let langLabel = cyan("Lang ")
-    let descLabel = dim("About")
-    print("")
-    print(top)
-    print("  |")
-    print("  |   ${nameLine}")
-    print("  |   ${starsLabel} : ${stars}")
-    print("  |   ${langLabel} : ${lang}")
-    print("  |   ${descLabel} : ${desc}")
-    print("  |")
-    print(bot)
-    print(dim("  press any key to go back"))
-    let k = termReadKey()
-    match k {
-        Success { value } => print("")
-        Error { message } => print("")
-    }
+    "\n${top}\n  |\n  |   ${nameLine}\n  |   ${yellow("Stars")} : ${stars}\n  |   ${cyan("Lang ")} : ${lang}\n  |   ${dim("About")} : ${desc}\n  |\n${bot}\n${dim("  press any key to go back")}"
 }
 
-// ---- selection movement -----------------------------------------------------
-// Checked arithmetic (+/-) returns Result<int, MathError>; unwrap it explicitly
-// with a fallback so the result is a plain int usable directly in a match arm.
-fn dec(x: int) -> int = {
-    let r = x - 1
-    match r {
-        Success { value } => value
-        Error { message } => x
-    }
+// ---- selection movement (pure int -> int) -----------------------------------
+fn moveUp(sel: int) -> int = match sel > 0 {
+    true => dec(sel)
+    false => sel
 }
 
-fn inc(x: int) -> int = {
-    let r = x + 1
-    match r {
-        Success { value } => value
-        Error { message } => x
-    }
+fn moveDown(sel: int, n: int) -> int = match sel < dec(n) {
+    true => inc(sel)
+    false => sel
 }
 
-fn moveUp(sel: int) -> int = {
-    match sel > 0 {
-        true => dec(sel)
-        false => sel
-    }
+// ---- screens: draw is the ONLY place that touches the terminal --------------
+fn drawScreen(doc: int, sel: int, n: int) -> Unit = {
+    let cleared = termClear()
+    print(screenText(doc: doc, sel: sel, n: n))
 }
 
-fn moveDown(sel: int, n: int) -> int = {
-    let last = dec(n)
-    match sel < last {
-        true => inc(sel)
-        false => sel
-    }
+fn detailView(doc: int, sel: int) -> Unit = {
+    let cleared = termClear()
+    let shown = print(detailText(doc: doc, sel: sel))
+    match termReadKey() { _ => print("") }
 }
 
 fn endApp() -> Unit = {
-    let r = termRawMode(0)
-    let s = termShowCursor()
+    let raw = termRawMode(0)
+    let cursor = termShowCursor()
     print(green("  Goodbye!"))
 }
 
 // ---- the render / input loop (recursion stands in for a while-loop) ---------
 fn uiLoop(doc: int, sel: int, n: int) -> Unit = {
     let drawn = drawScreen(doc: doc, sel: sel, n: n)
-    let k = termReadKey()
-    match k {
+    match termReadKey() {
         Success { value } => handleKey(doc: doc, sel: sel, n: n, key: value)
         Error { message } => endApp()
     }
 }
 
-fn handleKey(doc: int, sel: int, n: int, key: string) -> Unit = {
-    match key {
-        "q" => endApp()
-        "Esc" => endApp()
-        "Up" => uiLoop(doc: doc, sel: moveUp(sel), n: n)
-        "k" => uiLoop(doc: doc, sel: moveUp(sel), n: n)
-        "Down" => uiLoop(doc: doc, sel: moveDown(sel: sel, n: n), n: n)
-        "j" => uiLoop(doc: doc, sel: moveDown(sel: sel, n: n), n: n)
-        "Enter" => openDetail(doc: doc, sel: sel, n: n)
-        _ => uiLoop(doc: doc, sel: sel, n: n)
-    }
+fn handleKey(doc: int, sel: int, n: int, key: string) -> Unit = match key {
+    "q" => endApp()
+    "Esc" => endApp()
+    "Up" => uiLoop(doc: doc, sel: moveUp(sel), n: n)
+    "k" => uiLoop(doc: doc, sel: moveUp(sel), n: n)
+    "Down" => uiLoop(doc: doc, sel: moveDown(sel: sel, n: n), n: n)
+    "j" => uiLoop(doc: doc, sel: moveDown(sel: sel, n: n), n: n)
+    "Enter" => openDetail(doc: doc, sel: sel, n: n)
+    _ => uiLoop(doc: doc, sel: sel, n: n)
 }
 
 fn openDetail(doc: int, sel: int, n: int) -> Unit = {
@@ -189,17 +155,14 @@ fn openDetail(doc: int, sel: int, n: int) -> Unit = {
 
 // startUi parses the fetched JSON, enters raw mode + alternate screen, and runs
 // the interactive loop over the live repository list.
-fn startUi(bodyText: string) -> Unit = {
-    let doc = jsonParse(bodyText)
-    match doc {
-        Success { value } => {
-            let n = jsonLength(value, "")
-            let raw = termRawMode(1)
-            let hidden = termHideCursor()
-            uiLoop(doc: value, sel: 0, n: n)
-        }
-        Error { message } => print("JSON parse failed")
+fn startUi(bodyText: string) -> Unit = match jsonParse(bodyText) {
+    Success { value } => {
+        let n = jsonLength(value, "")
+        let raw = termRawMode(1)
+        let hidden = termHideCursor()
+        uiLoop(doc: value, sel: 0, n: n)
     }
+    Error { message } => print("JSON parse failed")
 }
 
 fn run() -> Unit = {
@@ -207,12 +170,13 @@ fn run() -> Unit = {
     // User-Agent header and rejects requests without one.
     let clientId = httpCreateClient("https://api.github.com", 10000)
     let path = "/users/${githubUser()}/repos?per_page=30&sort=updated"
-    let resp = httpGetResponse(clientId, path, "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n")
+    let headers = "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n"
+    let resp = httpGetResponse(clientId, path, headers)
     match resp {
         Success { value } => {
             let body = httpResponseBody(value)
             match body {
-                Success { text } => startUi(bodyText: text)
+                Success { text } => startUi(text)
                 Error { message } => print("Could not read response body")
             }
             let freed = httpResponseFree(value)

--- a/compiler/examples/tui/api_browser.osp
+++ b/compiler/examples/tui/api_browser.osp
@@ -172,40 +172,33 @@ fn startUi(bodyText: string) -> Unit ![Console, Terminal] = match jsonParse(body
 // The whole program in one effectful expression: fetch, then browse the result.
 fn app() -> Unit ![Console, Terminal, Http] = match perform Http.fetch("/users/${githubUser()}/repos?per_page=30&sort=updated") {
     Success { text } => startUi(text)
-    Error { message } => perform Console.print("Request failed")
+    Error { message } => perform Console.print("Request failed: ${message}")
 }
 
 // ---- interpretation: the ONLY place real I/O happens ------------------------
 // The Http handler hides the entire client/response lifecycle behind one
-// `fetch`. The client id rides as a parameter (used for both the request and
-// the close); the response handle is matched the instant it is produced.
+// `fetch`. Resource ordering falls out of eager argument evaluation: the body
+// is read while the handle is open, then `freeAfter` frees the handle, then
+// `closeAfter` closes the client - each threading the body Result through
+// untouched. No locals: the Result rides through as a parameter.
 fn ghHeaders() -> string = "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n"
 
 fn fetchBody(path: string) -> Result<string, Error> =
     dispatch(clientId: httpCreateClient("https://api.github.com", 10000), path: path)
 
 fn dispatch(clientId: int, path: string) -> Result<string, Error> = match httpGetResponse(clientId, path, ghHeaders()) {
-    Success { value } => readClose(clientId: clientId, value: value)
-    Error { message } => failClose(clientId: clientId)
+    Success { value } => closeAfter(clientId: clientId, result: freeAfter(value: value, result: httpResponseBody(value)))
+    Error { message } => closeAfter(clientId: clientId, result: Error { message: message })
 }
 
-// Read the body while the handle is open, then free it and close the client,
-// finally yielding the body. The body must be held in a binding across the
-// free/close: Osprey currently unwraps a Result passed through a parameter, so
-// parameter-lifting the body (as elsewhere) is impossible here - it stays local.
-fn readClose(clientId: int, value: int) -> Result<string, Error> = {
-    let body = httpResponseBody(value)
+fn freeAfter(value: int, result: Result<string, Error>) -> Result<string, Error> = {
     httpResponseFree(value)
-    httpCloseClient(clientId)
-    body
+    result
 }
 
-// On request failure there is no handle to read; close the client and surface a
-// failed Result. Osprey can't construct an `Error { ... }` literal of the right
-// type, so the failure value is produced by reading an invalid handle.
-fn failClose(clientId: int) -> Result<string, Error> = {
+fn closeAfter(clientId: int, result: Result<string, Error>) -> Result<string, Error> = {
     httpCloseClient(clientId)
-    httpResponseBody(0 - 1)
+    result
 }
 
 // `main` installs the handlers that discharge each effect into real I/O, then

--- a/compiler/examples/tui/api_browser.osp
+++ b/compiler/examples/tui/api_browser.osp
@@ -1,26 +1,36 @@
 // ============================================================================
-//  Osprey TUI showcase: a colored, arrow-key-driven browser that calls a REAL
-//  HTTP API over TLS and renders the live JSON response. Run it:
+//  Osprey TUI showcase: a colored, arrow-key-driven browser over a REAL HTTP
+//  API, written in the algebraic-effects style. Run it:
 //
 //      osprey examples/tui/api_browser.osp --run
 //
 //  Keys:  Up / Down (or k / j) move   Enter open details   q / Esc quit
 //
-//  It fetches live public repositories from the GitHub REST API
-//  (https://api.github.com/users/<user>/repos) over HTTPS, parses the JSON,
-//  and renders a colored, arrow-key-navigable list on the alternate screen.
+//  Every side effect is an ALGEBRAIC EFFECT. The program logic never touches
+//  a socket, a file descriptor or a terminal ioctl - it only `perform`s:
+//      perform Console.print(line)        -- write a line of output
+//      perform Terminal.readKey()         -- await one keystroke
+//      perform Terminal.raw(1)            -- enter/leave raw mode
+//      perform Http.fetch(path)           -- GET a path, yield the body
+//  The messy interpretation - opening a TLS client, reading the response,
+//  freeing the handle, closing the client, calling tcsetattr - lives ONLY in
+//  the handlers installed by `main`, where effects are discharged into real
+//  I/O. Swap those handlers and the same UI runs against a mock, a recording,
+//  or a test harness, with zero changes to the logic below.
 //
-//  Expression-only: there are NO local bindings. Every screen is a string
-//  built by composing pure functions and concatenating with `+`. A value that
-//  more than one expression needs (the http client, a response handle, a row's
-//  columns) rides as a function PARAMETER instead of a local. Terminal control
-//  is just text - the clear/show-cursor ANSI escapes are folded straight into
-//  the printed string, so only the genuine tcsetattr syscall (termRawMode)
-//  stays a call. The loop is recursion: each keystroke tail-calls the next frame.
-//  Builtins exercised: httpCreateClient/httpGetResponse/httpResponseBody
-//  [HTTP-RESPONSE-HANDLE], jsonParse/jsonGet/jsonLength [BUILTIN-JSON],
-//  termRawMode/termReadKey [BUILTIN-TERM], \e ANSI escapes.
+//  The render loop is recursion (Osprey has no loop keyword); each keystroke
+//  tail-calls the next frame. Screens are strings built by composing pure
+//  functions. Terminal control codes are just text folded into those strings.
+//  [BUILTIN-JSON] jsonParse/jsonGet/jsonLength, [HTTP-RESPONSE-HANDLE], \e ANSI.
 // ============================================================================
+
+// ---- effects: the complete vocabulary of side effects this program has ------
+effect Console { print: fn(string) -> Unit }
+effect Terminal {
+    readKey: fn() -> Result<string, Error>
+    raw:     fn(int) -> Unit
+}
+effect Http { fetch: fn(string) -> Result<string, Error> }
 
 // Which GitHub account's public repositories to browse.
 fn githubUser() -> string = "MelbourneDeveloper"
@@ -108,33 +118,32 @@ fn moveDown(sel: int, n: int) -> int = match sel < dec(n) {
     false => sel
 }
 
-// ---- screens: terminal control is just text -------------------------------
-// \e[2J\e[H clears + homes the cursor; \e[?25h shows it. Folding these escapes
-// into the printed string means a "clear" is a character, not a side effect.
-fn drawScreen(doc: int, sel: int, n: int) -> Unit = print("\e[2J\e[H" + screenText(doc: doc, sel: sel, n: n))
+// ---- the UI: pure effect logic. No I/O primitives appear below. -------------
+// \e[?25l hides the cursor, \e[2J\e[H clears + homes; folding them into the
+// printed frame means "clear screen" is text, performed through Console.
+fn drawScreen(doc: int, sel: int, n: int) -> Unit !Console =
+    perform Console.print("\e[?25l\e[2J\e[H" + screenText(doc: doc, sel: sel, n: n))
 
-fn detailView(doc: int, sel: int) -> Unit = {
-    print("\e[2J\e[H" + detailText(doc: doc, sel: sel))
-    match termReadKey() { _ => print("") }
+fn detailView(doc: int, sel: int) -> Unit ![Console, Terminal] = {
+    perform Console.print("\e[2J\e[H" + detailText(doc: doc, sel: sel))
+    match perform Terminal.readKey() { _ => perform Console.print("") }
 }
 
-// termRawMode is a real tcsetattr syscall (it also toggles the alternate
-// screen), so it stays a call; the show-cursor escape folds into the farewell.
-fn endApp() -> Unit = {
-    termRawMode(0)
-    print("\e[?25h" + green("  Goodbye!"))
+fn endApp() -> Unit ![Console, Terminal] = {
+    perform Terminal.raw(0)
+    perform Console.print("\e[?25h" + green("  Goodbye!"))
 }
 
 // ---- the render / input loop (recursion stands in for a while-loop) ---------
-fn uiLoop(doc: int, sel: int, n: int) -> Unit = {
+fn uiLoop(doc: int, sel: int, n: int) -> Unit ![Console, Terminal] = {
     drawScreen(doc: doc, sel: sel, n: n)
-    match termReadKey() {
+    match perform Terminal.readKey() {
         Success { value } => handleKey(doc: doc, sel: sel, n: n, key: value)
         Error { message } => endApp()
     }
 }
 
-fn handleKey(doc: int, sel: int, n: int, key: string) -> Unit = match key {
+fn handleKey(doc: int, sel: int, n: int, key: string) -> Unit ![Console, Terminal] = match key {
     "q" => endApp()
     "Esc" => endApp()
     "Up" => uiLoop(doc: doc, sel: moveUp(sel), n: n)
@@ -145,42 +154,70 @@ fn handleKey(doc: int, sel: int, n: int, key: string) -> Unit = match key {
     _ => uiLoop(doc: doc, sel: sel, n: n)
 }
 
-fn openDetail(doc: int, sel: int, n: int) -> Unit = {
+fn openDetail(doc: int, sel: int, n: int) -> Unit ![Console, Terminal] = {
     detailView(doc: doc, sel: sel)
     uiLoop(doc: doc, sel: sel, n: n)
 }
 
-// startUi enters raw mode + the alternate screen, hides the cursor, and runs
-// the interactive loop over the live repository list.
-fn startUi(bodyText: string) -> Unit = match jsonParse(bodyText) {
+// startUi enters raw mode + the alternate screen and runs the loop over the
+// live repository list. Raw mode is requested as an effect, not a syscall.
+fn startUi(bodyText: string) -> Unit ![Console, Terminal] = match jsonParse(bodyText) {
     Success { value } => {
-        termRawMode(1)
-        termHideCursor()
+        perform Terminal.raw(1)
         uiLoop(doc: value, sel: 0, n: jsonLength(value, ""))
     }
-    Error { message } => print("JSON parse failed")
+    Error { message } => perform Console.print("JSON parse failed")
 }
 
-// ---- HTTP plumbing ----------------------------------------------------------
-// The client id and the response handle are each needed twice (request then
-// close; read then free), so they travel as parameters rather than locals.
-fn run() -> Unit = browse(httpCreateClient("https://api.github.com", 10000))
+// The whole program in one effectful expression: fetch, then browse the result.
+fn app() -> Unit ![Console, Terminal, Http] = match perform Http.fetch("/users/${githubUser()}/repos?per_page=30&sort=updated") {
+    Success { text } => startUi(text)
+    Error { message } => perform Console.print("Request failed")
+}
 
-fn browse(clientId: int) -> Unit = {
-    // GitHub requires a User-Agent header and rejects requests without one.
-    match httpGetResponse(clientId, "/users/${githubUser()}/repos?per_page=30&sort=updated", "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n") {
-        Success { value } => useResponse(value)
-        Error { message } => print("Request failed: ${message}")
-    }
+// ---- interpretation: the ONLY place real I/O happens ------------------------
+// The Http handler hides the entire client/response lifecycle behind one
+// `fetch`. The client id rides as a parameter (used for both the request and
+// the close); the response handle is matched the instant it is produced.
+fn ghHeaders() -> string = "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n"
+
+fn fetchBody(path: string) -> Result<string, Error> =
+    dispatch(clientId: httpCreateClient("https://api.github.com", 10000), path: path)
+
+fn dispatch(clientId: int, path: string) -> Result<string, Error> = match httpGetResponse(clientId, path, ghHeaders()) {
+    Success { value } => readClose(clientId: clientId, value: value)
+    Error { message } => failClose(clientId: clientId)
+}
+
+// Read the body while the handle is open, then free it and close the client,
+// finally yielding the body. The body must be held in a binding across the
+// free/close: Osprey currently unwraps a Result passed through a parameter, so
+// parameter-lifting the body (as elsewhere) is impossible here - it stays local.
+fn readClose(clientId: int, value: int) -> Result<string, Error> = {
+    let body = httpResponseBody(value)
+    httpResponseFree(value)
     httpCloseClient(clientId)
+    body
 }
 
-fn useResponse(resp: int) -> Unit = {
-    match httpResponseBody(resp) {
-        Success { text } => startUi(text)
-        Error { message } => print("Could not read response body")
+// On request failure there is no handle to read; close the client and surface a
+// failed Result. Osprey can't construct an `Error { ... }` literal of the right
+// type, so the failure value is produced by reading an invalid handle.
+fn failClose(clientId: int) -> Result<string, Error> = {
+    httpCloseClient(clientId)
+    httpResponseBody(0 - 1)
+}
+
+// `main` installs the handlers that discharge each effect into real I/O, then
+// runs the pure effect logic underneath them.
+fn main() -> Unit =
+    handle Console
+        print line => print(line)
+    in handle Terminal
+        readKey => termReadKey()
+        raw on => termRawMode(on)
+    in handle Http
+        fetch path => fetchBody(path)
+    in {
+        app()
     }
-    httpResponseFree(resp)
-}
-
-run()

--- a/compiler/examples/tui/api_browser.osp
+++ b/compiler/examples/tui/api_browser.osp
@@ -1,28 +1,24 @@
 // ============================================================================
-//  Osprey TUI showcase: a colored, arrow-key-driven browser that calls an
-//  HTTP API and renders the JSON response. Run it:
+//  Osprey TUI showcase: a colored, arrow-key-driven browser that calls a REAL
+//  HTTP API over TLS and renders the live JSON response. Run it:
 //
 //      osprey examples/tui/api_browser.osp --run
 //
 //  Keys:  Up / Down (or k / j) move   Enter open details   q / Esc quit
 //
-//  Architecture: a local HTTP server stands in for "an arbitrary API" so the
-//  demo is self-contained. The render loop is expressed as recursion (Osprey
-//  has no loop keyword) - each keystroke tail-calls the next frame.
-//  Builtins exercised: httpGetResponse/httpResponseBody [HTTP-RESPONSE-HANDLE],
-//  jsonParse/jsonGet/jsonLength [BUILTIN-JSON], termRawMode/termReadKey/
-//  termClear/termHideCursor/termShowCursor [BUILTIN-TERM], \e ANSI escapes.
+//  It fetches live public repositories from the GitHub REST API
+//  (https://api.github.com/users/<user>/repos) over HTTPS, parses the JSON,
+//  and renders a colored, arrow-key-navigable list on the alternate screen.
+//  The render loop is expressed as recursion (Osprey has no loop keyword) -
+//  each keystroke tail-calls the next frame.
+//  Builtins exercised: httpCreateClient/httpGetResponse/httpResponseBody
+//  [HTTP-RESPONSE-HANDLE], jsonParse/jsonGet/jsonLength [BUILTIN-JSON],
+//  termRawMode/termReadKey/termClear/termHideCursor/termShowCursor
+//  [BUILTIN-TERM], \e ANSI escapes.
 // ============================================================================
 
-// ---- the "API": a local server returning a JSON array of repositories ------
-fn handleRequest(method: string, path: string, headers: string, body: string) -> HttpResponse = HttpResponse {
-    status: 200,
-    headers: "Content-Type: application/json",
-    contentType: "application/json",
-    streamFd: -1,
-    isComplete: true,
-    partialBody: "[{\"name\":\"osprey\",\"stars\":1200,\"lang\":\"Go\",\"desc\":\"A functional language with compile-time algebraic effects\"},{\"name\":\"llvm\",\"stars\":9001,\"lang\":\"C++\",\"desc\":\"Modular compiler and toolchain infrastructure\"},{\"name\":\"antlr\",\"stars\":4200,\"lang\":\"Java\",\"desc\":\"Powerful parser generator for reading and processing text\"},{\"name\":\"ziglang\",\"stars\":3300,\"lang\":\"Zig\",\"desc\":\"A general-purpose language and toolchain for robust software\"}]"
-}
+// Which GitHub account's public repositories to browse.
+fn githubUser() -> string = "MelbourneDeveloper"
 
 // ---- ANSI color helpers (pure string wrappers) -----------------------------
 fn cyan(s: string) -> string = "\e[36m${s}\e[0m"
@@ -55,9 +51,9 @@ fn renderItem(doc: int, i: int, sel: int, n: int) -> Unit = {
     match i < n {
         true => {
             let name = field(doc: doc, path: "[${i}].name")
-            let stars = field(doc: doc, path: "[${i}].stars")
-            let lang = field(doc: doc, path: "[${i}].lang")
-            let nameP = pad(s: name, n: 14)
+            let stars = field(doc: doc, path: "[${i}].stargazers_count")
+            let lang = field(doc: doc, path: "[${i}].language")
+            let nameP = pad(s: name, n: 20)
             let starP = pad(s: stars, n: 7)
             let row = "${nameP}* ${starP}${lang}"
             let selected = i == sel
@@ -82,8 +78,8 @@ fn renderItem(doc: int, i: int, sel: int, n: int) -> Unit = {
 
 fn drawScreen(doc: int, sel: int, n: int) -> Unit = {
     let cleared = termClear()
-    let title = bold(cyan("  OSPREY   -   Repository Browser"))
-    let rule = dim("  ========================================")
+    let title = bold(cyan("  OSPREY  -  GitHub Repos: ${githubUser()}  (live API)"))
+    let rule = dim("  ==================================================")
     let hint = dim("  up/down or j/k move    enter details    q quit")
     print("")
     print(title)
@@ -97,9 +93,9 @@ fn drawScreen(doc: int, sel: int, n: int) -> Unit = {
 fn detailView(doc: int, sel: int) -> Unit = {
     let cleared = termClear()
     let name = field(doc: doc, path: "[${sel}].name")
-    let stars = field(doc: doc, path: "[${sel}].stars")
-    let lang = field(doc: doc, path: "[${sel}].lang")
-    let desc = field(doc: doc, path: "[${sel}].desc")
+    let stars = field(doc: doc, path: "[${sel}].stargazers_count")
+    let lang = field(doc: doc, path: "[${sel}].language")
+    let desc = field(doc: doc, path: "[${sel}].description")
     let top = magenta("  +-- Repository ------------------------------+")
     let bot = magenta("  +--------------------------------------------+")
     let nameLine = bold(green(name))
@@ -191,32 +187,39 @@ fn openDetail(doc: int, sel: int, n: int) -> Unit = {
     uiLoop(doc: doc, sel: sel, n: n)
 }
 
+// startUi parses the fetched JSON, enters raw mode + alternate screen, and runs
+// the interactive loop over the live repository list.
+fn startUi(bodyText: string) -> Unit = {
+    let doc = jsonParse(bodyText)
+    match doc {
+        Success { value } => {
+            let n = jsonLength(value, "")
+            let raw = termRawMode(1)
+            let hidden = termHideCursor()
+            uiLoop(doc: value, sel: 0, n: n)
+        }
+        Error { message } => print("JSON parse failed")
+    }
+}
+
 fn run() -> Unit = {
-    let serverId = httpCreateServer(18097, "127.0.0.1")
-    let listenResult = httpListen(serverId, handleRequest)
-    let clientId = httpCreateClient("http://127.0.0.1:18097", 5000)
-    let resp = httpGetResponse(clientId, "/repos", "")
+    // Real, live HTTPS call to the GitHub REST API. GitHub requires a
+    // User-Agent header and rejects requests without one.
+    let clientId = httpCreateClient("https://api.github.com", 10000)
+    let path = "/users/${githubUser()}/repos?per_page=30&sort=updated"
+    let resp = httpGetResponse(clientId, path, "User-Agent: osprey-tui\r\nAccept: application/vnd.github+json\r\n")
     match resp {
         Success { value } => {
             let body = httpResponseBody(value)
             match body {
-                Success { value } => {
-                    let doc = jsonParse(value)
-                    match doc {
-                        Success { value } => {
-                            let n = jsonLength(value, "")
-                            let raw = termRawMode(1)
-                            let hidden = termHideCursor()
-                            uiLoop(doc: value, sel: 0, n: n)
-                        }
-                        Error { message } => print("JSON parse failed")
-                    }
-                }
+                Success { text } => startUi(bodyText: text)
                 Error { message } => print("Could not read response body")
             }
+            let freed = httpResponseFree(value)
         }
         Error { message } => print("Request failed: ${message}")
     }
+    let closed = httpCloseClient(clientId)
 }
 
 run()

--- a/compiler/internal/codegen/effects_generation.go
+++ b/compiler/internal/codegen/effects_generation.go
@@ -365,6 +365,10 @@ func (ec *EffectCodegen) generateHandlerFunctionBody(
 		if isScalarLLVMType(returnType) && ec.generator.isResultType(bodyResult) {
 			bodyResult = ec.generator.unwrapIfResult(bodyResult)
 		}
+		// A handler arm returning a Result (e.g. `readKey => termReadKey()`)
+		// produces a pointer to the Result struct; the handler returns the
+		// struct by value. Load it so llc accepts the `ret`.
+		bodyResult = ec.generator.coerceReturnToRetType(bodyResult, returnType)
 		ec.generator.builder.NewRet(bodyResult)
 	} else {
 		// Handle default return values for different types

--- a/compiler/internal/codegen/function_signatures.go
+++ b/compiler/internal/codegen/function_signatures.go
@@ -35,14 +35,32 @@ const (
 // entry with the fully-inferred type scheme; the placeholder only exists to
 // keep forward references from failing the identifier lookup.
 func (g *LLVMGenerator) preDeclareFunctionPlaceholder(fnDecl *ast.FunctionDeclaration) {
+	// Use explicitly-annotated parameter and return types in the placeholder so
+	// a forward reference resolves to the real signature, not a bare type
+	// variable. Without this, calling a function declared later in source —
+	// e.g. one returning Result<string, Error> — yields a fresh return var, and
+	// sibling match arms calling it fail to unify. Unannotated slots stay fresh
+	// (inferred when declareFunctionSignature runs and overwrites this entry).
 	paramTypes := make([]Type, len(fnDecl.Parameters))
-	for i := range fnDecl.Parameters {
-		paramTypes[i] = g.typeInferer.Fresh()
+	for i, param := range fnDecl.Parameters {
+		switch {
+		case param.Type == nil:
+			paramTypes[i] = g.typeInferer.Fresh()
+		case param.Type.IsFunction:
+			paramTypes[i] = g.buildFunctionTypeFromAST(param.Type)
+		default:
+			paramTypes[i] = g.typeExpressionToInferenceType(param.Type)
+		}
+	}
+
+	var returnType Type = g.typeInferer.Fresh()
+	if fnDecl.ReturnType != nil {
+		returnType = g.typeExpressionToInferenceType(fnDecl.ReturnType)
 	}
 
 	g.typeInferer.env.Set(fnDecl.Name, &FunctionType{
 		paramTypes: paramTypes,
-		returnType: g.typeInferer.Fresh(),
+		returnType: returnType,
 	})
 }
 

--- a/compiler/internal/codegen/function_signatures.go
+++ b/compiler/internal/codegen/function_signatures.go
@@ -895,6 +895,24 @@ func (g *LLVMGenerator) coerceReturnToRetType(val value.Value, expected types.Ty
 	if val == nil || expected == nil || expected.Equal(val.Type()) {
 		return val
 	}
+	// By-value struct return from a pointer: a Result-returning function whose
+	// body builds the Result in an alloca (e.g. the body is itself a Result, as
+	// in `fn f() -> Result<string, Error> = httpResponseBody(h)`) hands back a
+	// pointer to the struct, but the function returns the struct by value. Load
+	// it — strict llc rejects `ret {..}* %p` where the result type is `{..}`.
+	// The stored struct may use typed pointers ({i8*, i8}) while the declared
+	// return type uses opaque ({ptr, i8}); bitcast the pointer first so the load
+	// type matches, then load the expected struct value.
+	if expectedStruct, ok := expected.(*types.StructType); ok {
+		if _, ok := val.Type().(*types.PointerType); ok {
+			ptr := val
+			wantPtr := types.NewPointer(expectedStruct)
+			if !ptr.Type().Equal(wantPtr) {
+				ptr = g.builder.NewBitCast(ptr, wantPtr)
+			}
+			return g.builder.NewLoad(expectedStruct, ptr)
+		}
+	}
 	if _, expectedIsPtr := expected.(*types.PointerType); expectedIsPtr {
 		if _, actualIsPtr := val.Type().(*types.PointerType); actualIsPtr {
 			return g.builder.NewBitCast(val, expected)

--- a/compiler/internal/codegen/llvm.go
+++ b/compiler/internal/codegen/llvm.go
@@ -298,6 +298,22 @@ func (g *LLVMGenerator) coerceArgumentToParamType(
 	case expected.Equal(types.I8Ptr) && actual.Equal(types.I64):
 		return g.builder.NewIntToPtr(val, types.I8Ptr)
 	}
+	// By-value struct parameter fed a pointer-to-struct: a Result built in an
+	// alloca (or otherwise handed back as a pointer) passed into a Result
+	// parameter. Load it so the struct is passed by value. Mirror of
+	// coerceReturnToRetType; the stored struct may use typed pointers while the
+	// parameter uses opaque, so bitcast the pointer to match before loading.
+	if expectedStruct, ok := expected.(*types.StructType); ok {
+		if _, actualIsPtr := actual.(*types.PointerType); actualIsPtr {
+			ptr := val
+			wantPtr := types.NewPointer(expectedStruct)
+			if !ptr.Type().Equal(wantPtr) {
+				ptr = g.builder.NewBitCast(ptr, wantPtr)
+			}
+
+			return g.builder.NewLoad(expectedStruct, ptr)
+		}
+	}
 	// Pointer-to-pointer: bitcast. Hits when a recursive-union field stored as
 	// i8* (see [TYPE-UNION-REC]) is loaded and then passed back to a function
 	// declared with the concrete union-struct pointer type.
@@ -350,7 +366,34 @@ func (g *LLVMGenerator) generateArgumentExpression(
 	// AUTO-UNWRAP Result types for function arguments per spec (0004-TypeSystem.md:115-160)
 	// This matches the type inference behavior where Result types are automatically unwrapped
 	// Example: fibonacci(n - 1) where (n - 1) returns Result<int, MathError> but fibonacci expects int
+	// SUPPRESSED when the callee's parameter explicitly expects a Result, so the
+	// Result passes through intact (mirrors maybeUnwrapArg in type inference).
+	if g.calleeParamIsResult(callExpr, argIndex) {
+		return val, nil
+	}
+
 	return g.unwrapIfResult(val), nil
+}
+
+// calleeParamIsResult reports whether the function called by callExpr declares a
+// Result type at parameter argIndex. Named arguments must appear in declaration
+// order, so positional alignment holds. Used to suppress Result auto-unwrapping
+// of an argument destined for a Result parameter.
+func (g *LLVMGenerator) calleeParamIsResult(callExpr *ast.CallExpression, argIndex int) bool {
+	ident, ok := callExpr.Function.(*ast.Identifier)
+	if !ok {
+		return false
+	}
+	funcType, ok := g.typeInferer.env.Get(ident.Name)
+	if !ok {
+		return false
+	}
+	params := paramTypesOf(funcType)
+	if argIndex >= len(params) {
+		return false
+	}
+
+	return g.typeInferer.isResultType(params[argIndex])
 }
 
 // handlePolymorphicFunctionArgument handles polymorphic function arguments
@@ -2408,6 +2451,45 @@ func (g *LLVMGenerator) generateSuccessBlock(
 	return successValue, nil
 }
 
+// bindResultPayload binds fieldName to field 0 of the currently-matched Result
+// (the value/message slot) when that slot is a string pointer (i8*), returning
+// true. Used by the Error arm to surface the real message string; the Success
+// arm inlines the same extraction. Returns false when no Result is in scope or
+// the payload slot is not a string pointer (so the caller uses a stand-in).
+func (g *LLVMGenerator) bindResultPayload(fieldName string) bool {
+	if g.currentResultValue == nil {
+		return false
+	}
+
+	switch t := g.currentResultValue.Type().(type) {
+	case *types.PointerType:
+		st, ok := t.ElemType.(*types.StructType)
+		if !ok || len(st.Fields) == 0 {
+			return false
+		}
+		if _, isPtr := st.Fields[0].(*types.PointerType); !isPtr {
+			return false
+		}
+		payloadPtr := g.builder.NewGetElementPtr(st, g.currentResultValue,
+			constant.NewInt(types.I32, 0), constant.NewInt(types.I32, 0))
+		g.variables[fieldName] = g.builder.NewLoad(st.Fields[0], payloadPtr)
+
+		return true
+	case *types.StructType:
+		if len(t.Fields) == 0 {
+			return false
+		}
+		if _, isPtr := t.Fields[0].(*types.PointerType); !isPtr {
+			return false
+		}
+		g.variables[fieldName] = g.builder.NewExtractValue(g.currentResultValue, 0)
+
+		return true
+	default:
+		return false
+	}
+}
+
 // generateErrorBlock generates the error block for result matching.
 func (g *LLVMGenerator) generateErrorBlock(
 	matchExpr *ast.MatchExpression,
@@ -2445,24 +2527,26 @@ func (g *LLVMGenerator) generateErrorBlock(
 			}
 		}
 
-		// Create a unique global string for the error message
-		// Include function context to ensure uniqueness across monomorphized instances
-		funcContext := ""
-		if g.function != nil {
-			funcContext = g.function.Name()
+		// Bind `message` to the real error payload (field 0 of the Result
+		// struct), mirroring the Success arm — this propagates the string from
+		// `Error { message: ... }` instead of a stand-in. Only when that slot is
+		// a string pointer (i8*); for a non-string payload (e.g. Result<int, E>)
+		// the slot is not a message string, so fall back to a static stand-in.
+		// See docs/plans/error-payloads.md.
+		if !g.bindResultPayload(fieldName) {
+			funcContext := ""
+			if g.function != nil {
+				funcContext = g.function.Name()
+			}
+			blockSuffix := fmt.Sprintf("_%s_%p", funcContext, matchExpr)
+			errorStr := g.module.NewGlobalDef(
+				"error_msg"+blockSuffix,
+				constant.NewCharArrayFromString("Error occurred"+StringTerminator),
+			)
+			errorPtr := g.builder.NewGetElementPtr(errorStr.ContentType, errorStr,
+				constant.NewInt(types.I64, 0), constant.NewInt(types.I64, 0))
+			g.variables[fieldName] = errorPtr
 		}
-		blockSuffix := fmt.Sprintf("_%s_%p", funcContext, matchExpr)
-		// NOTE: the runtime payload slot for Result error messages is not yet
-		// threaded through (see docs/plans/error-payloads.md), so codegen still
-		// substitutes a static stand-in. The previous spelling used a literal
-		// backslash sequence which leaked the chars "\x00" into output.
-		errorStr := g.module.NewGlobalDef(
-			"error_msg"+blockSuffix,
-			constant.NewCharArrayFromString("Error occurred"+StringTerminator),
-		)
-		errorPtr := g.builder.NewGetElementPtr(errorStr.ContentType, errorStr,
-			constant.NewInt(types.I64, 0), constant.NewInt(types.I64, 0))
-		g.variables[fieldName] = errorPtr
 	}
 
 	errorExpr := g.findErrorValue(matchExpr)

--- a/compiler/internal/codegen/type_inference.go
+++ b/compiler/internal/codegen/type_inference.go
@@ -985,6 +985,23 @@ func (ti *TypeInferer) extractResultErrorType(resultTypeName string) Type {
 	return &ConcreteType{name: TypeString} // fallback
 }
 
+// isResultType reports whether t denotes a Result<...> type, in either the
+// ConcreteType-with-stringified-name form (used for builtin return types and
+// type annotations) or a GenericType named Result. Used to decide when NOT to
+// auto-unwrap a Result argument: a parameter that explicitly expects a Result
+// must receive it intact (so `fn f(r: Result<string, Error>)` is callable).
+func (ti *TypeInferer) isResultType(t Type) bool {
+	resolved := ti.prune(t)
+	if gt, ok := resolved.(*GenericType); ok {
+		return gt.name == TypeResult
+	}
+	if ct, ok := resolved.(*ConcreteType); ok {
+		return strings.HasPrefix(ct.String(), TypeResult+"<")
+	}
+
+	return false
+}
+
 // unwrapResultType unwraps a Result<T, E> type to just T
 // If the type is not a Result, returns it as-is
 func (ti *TypeInferer) unwrapResultType(t Type) Type {
@@ -1822,8 +1839,11 @@ func (ti *TypeInferer) inferCallExpression(e *ast.CallExpression) (Type, error) 
 		return nil, err
 	}
 
-	// Infer argument types
-	argTypes, err := ti.inferCallArguments(e)
+	// Infer argument types. The callee's parameter types steer Result
+	// auto-unwrapping: a Result argument is unwrapped to its success type for a
+	// plain parameter (so fibonacci(n - 1) works), but kept intact when the
+	// parameter explicitly expects a Result.
+	argTypes, err := ti.inferCallArguments(e, paramTypesOf(funcType))
 	if err != nil {
 		return nil, err
 	}
@@ -1855,55 +1875,62 @@ func (ti *TypeInferer) validateBuiltInCall(e *ast.CallExpression) error {
 	return ti.validateBuiltInFunctionArgs(ident.Name, argCount, e.Position)
 }
 
-// inferCallArguments infers types for all call arguments
-func (ti *TypeInferer) inferCallArguments(e *ast.CallExpression) ([]Type, error) {
+// inferCallArguments infers types for all call arguments. paramTypes are the
+// callee's declared parameter types (positionally aligned — named arguments
+// must appear in declaration order), used to decide per-argument whether a
+// Result is auto-unwrapped.
+func (ti *TypeInferer) inferCallArguments(e *ast.CallExpression, paramTypes []Type) ([]Type, error) {
 	if len(e.NamedArguments) > 0 {
-		return ti.inferNamedArguments(e.NamedArguments)
+		return ti.inferNamedArguments(e.NamedArguments, paramTypes)
 	}
 
-	return ti.inferRegularArguments(e.Arguments)
+	return ti.inferRegularArguments(e.Arguments, paramTypes)
 }
 
 // inferNamedArguments infers types for named arguments
-func (ti *TypeInferer) inferNamedArguments(namedArgs []ast.NamedArgument) ([]Type, error) {
+func (ti *TypeInferer) inferNamedArguments(namedArgs []ast.NamedArgument, paramTypes []Type) ([]Type, error) {
 	var argTypes []Type
 
-	for _, namedArg := range namedArgs {
+	for i, namedArg := range namedArgs {
 		argType, err := ti.InferType(namedArg.Value)
 		if err != nil {
 			return nil, err
 		}
 
-		// AUTO-UNWRAP Result types for function arguments per spec (0004-TypeSystem.md:115-160)
-		// This allows fibonacci(n - 1) where (n - 1) returns Result<int, MathError>
-		// The unwrapped type is used for type inference, actual unwrapping happens at codegen
-		argType = ti.unwrapResultType(argType)
-
-		argTypes = append(argTypes, argType)
+		argTypes = append(argTypes, ti.maybeUnwrapArg(argType, paramTypes, i))
 	}
 
 	return argTypes, nil
 }
 
 // inferRegularArguments infers types for regular arguments
-func (ti *TypeInferer) inferRegularArguments(args []ast.Expression) ([]Type, error) {
+func (ti *TypeInferer) inferRegularArguments(args []ast.Expression, paramTypes []Type) ([]Type, error) {
 	var argTypes []Type
 
-	for _, arg := range args {
+	for i, arg := range args {
 		argType, err := ti.InferType(arg)
 		if err != nil {
 			return nil, err
 		}
 
-		// AUTO-UNWRAP Result types for function arguments per spec (0004-TypeSystem.md:115-160)
-		// This allows fibonacci(n - 1) where (n - 1) returns Result<int, MathError>
-		// The unwrapped type is used for type inference, actual unwrapping happens at codegen
-		argType = ti.unwrapResultType(argType)
-
-		argTypes = append(argTypes, argType)
+		argTypes = append(argTypes, ti.maybeUnwrapArg(argType, paramTypes, i))
 	}
 
 	return argTypes, nil
+}
+
+// maybeUnwrapArg applies the Result auto-unwrap rule (0004-TypeSystem.md:115-160)
+// to argument i: a Result<T, E> argument is unwrapped to T so calls like
+// fibonacci(n - 1) — where (n - 1) is Result<int, MathError> — type-check. The
+// unwrap is SUPPRESSED when the matching parameter explicitly expects a Result,
+// so a Result can be passed through a parameter intact. Actual value unwrapping
+// still happens at codegen.
+func (ti *TypeInferer) maybeUnwrapArg(argType Type, paramTypes []Type, i int) Type {
+	if i < len(paramTypes) && ti.isResultType(paramTypes[i]) {
+		return argType
+	}
+
+	return ti.unwrapResultType(argType)
 }
 
 // validateArgumentTypes validates that no arguments have 'any' type. The
@@ -2643,10 +2670,11 @@ func (ti *TypeInferer) inferTypeConstructor(e *ast.TypeConstructorExpression) (T
 			return nil, err
 		}
 
-		// Create Result<T, string> type where T is the value type
-		errorType := &ConcreteType{name: "string"}
-
-		return CreateResultType(valueType, errorType), nil
+		// A Success carries no error, so the error type is left polymorphic (a
+		// fresh variable). It unifies with whatever error type the context — a
+		// return annotation or surrounding match — requires (Error, StringError,
+		// MathError, …), instead of being pinned to one concrete type.
+		return CreateResultType(valueType, ti.Fresh()), nil
 	}
 
 	// Special handling for Error constructor
@@ -2656,16 +2684,18 @@ func (ti *TypeInferer) inferTypeConstructor(e *ast.TypeConstructorExpression) (T
 			return nil, ErrErrorConstructorMissingMessage
 		}
 
-		// Infer the type of the message
-		messageType, err := ti.InferType(messageExpr)
+		// Validate the message expression (catches undefined references etc.).
+		// The constructed value's error type is the standard Error type — NOT
+		// the message's type — and the success type is left polymorphic so it
+		// unifies with the context's success type. This is what lets
+		// `fn f() -> Result<string, Error> = Error { message: m }` type-check
+		// and propagate the real message.
+		_, err := ti.InferType(messageExpr)
 		if err != nil {
 			return nil, err
 		}
 
-		// Create Result<T, E> type where E is the message type and T is a fresh type variable
-		valueType := ti.Fresh()
-
-		return CreateResultType(valueType, messageType), nil
+		return CreateResultType(ti.Fresh(), &ConcreteType{name: ErrorPattern}), nil
 	}
 
 	// Look up constructor in environment

--- a/compiler/runtime/http_client_runtime.c
+++ b/compiler/runtime/http_client_runtime.c
@@ -1,5 +1,10 @@
 #include "http_shared.h"
 
+#include <strings.h> // strncasecmp
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
 // HTTP client runtime.
 //
 // Two request surfaces share one transport helper (http_perform):
@@ -29,6 +34,8 @@ int64_t http_create_client(char *base_url, int64_t timeout) {
   client->base_url = strdup(base_url);
   client->timeout = (int)timeout;
   client->is_persistent = false;
+  client->is_https = (strncmp(base_url, "https://", 8) == 0) ||
+                     (strncmp(base_url, "wss://", 6) == 0);
 
   // Parse base URL
   char *path;
@@ -46,10 +53,43 @@ int64_t http_create_client(char *base_url, int64_t timeout) {
   return id;
 }
 
+// transport_close tears down the TLS session (if any) and closes the socket.
+static void transport_close(SSL *ssl, SSL_CTX *ctx, int sock) {
+  if (ssl) {
+    SSL_shutdown(ssl);
+    SSL_free(ssl);
+  }
+  if (ctx) {
+    SSL_CTX_free(ctx);
+  }
+#ifdef _WIN32
+  closesocket(sock);
+#else
+  close(sock);
+#endif
+}
+
+// transport_send / transport_recv route I/O over TLS when ssl is set, otherwise
+// over the bare socket, so http_perform speaks both http:// and https://.
+static ssize_t transport_send(SSL *ssl, int sock, const char *buf, int len) {
+  if (ssl) {
+    return SSL_write(ssl, buf, len);
+  }
+  return send(sock, buf, (size_t)len, 0);
+}
+
+static ssize_t transport_recv(SSL *ssl, int sock, char *buf, int cap) {
+  if (ssl) {
+    return SSL_read(ssl, buf, cap);
+  }
+  return recv(sock, buf, (size_t)cap, 0);
+}
+
 // http_perform connects, sends the request and reads the ENTIRE response into a
 // freshly allocated, NUL-terminated buffer (the server uses Connection: close,
-// so recv() draining to EOF captures the whole body). Returns 0 on success with
-// *out_raw / *out_len set (caller frees *out_raw), or a negative error code.
+// so recv() draining to EOF captures the whole body). For https:// clients the
+// transport is wrapped in TLS. Returns 0 on success with *out_raw / *out_len
+// set (caller frees *out_raw), or a negative error code.
 static int64_t http_perform(int64_t client_id, int64_t method, char *path,
                             char *headers, char *body, char **out_raw,
                             size_t *out_len) {
@@ -100,14 +140,39 @@ static int64_t http_perform(int64_t client_id, int64_t method, char *path,
     return -5;
   }
 
+  // Establish a TLS session for https:// clients. SNI (the host name) is
+  // mandatory for virtual-hosted endpoints such as api.github.com.
+  SSL_CTX *ctx = NULL;
+  SSL *ssl = NULL;
+  if (client->is_https) {
+    ctx = SSL_CTX_new(TLS_client_method());
+    if (!ctx) {
+      transport_close(NULL, NULL, sock);
+      return -11;
+    }
+    ssl = SSL_new(ctx);
+    if (!ssl) {
+      transport_close(NULL, ctx, sock);
+      return -11;
+    }
+    SSL_set_fd(ssl, sock);
+    SSL_set_tlsext_host_name(ssl, client->host);
+    if (SSL_connect(ssl) != 1) {
+      transport_close(ssl, ctx, sock);
+      return -12;
+    }
+  }
+
   char request[MAX_HTTP_BUFFER];
   const char *method_str = http_method_to_string((HttpMethod)method);
 
+  // The Host header carries the bare host name (no :port) - servers like
+  // GitHub reject "Host: api.github.com:443" with 400.
   int request_len = snprintf(request, sizeof(request),
                              "%s %s HTTP/1.1\r\n"
-                             "Host: %s:%d\r\n"
+                             "Host: %s\r\n"
                              "Connection: close\r\n",
-                             method_str, path, client->host, client->port);
+                             method_str, path, client->host);
 
   if (headers && strlen(headers) > 0) {
     request_len += snprintf(request + request_len, sizeof(request) - request_len,
@@ -122,12 +187,8 @@ static int64_t http_perform(int64_t client_id, int64_t method, char *path,
                             sizeof(request) - request_len, "\r\n");
   }
 
-  if (send(sock, request, request_len, 0) < 0) {
-#ifdef _WIN32
-    closesocket(sock);
-#else
-    close(sock);
-#endif
+  if (transport_send(ssl, sock, request, request_len) < 0) {
+    transport_close(ssl, ctx, sock);
     return -6;
   }
 
@@ -135,11 +196,7 @@ static int64_t http_perform(int64_t client_id, int64_t method, char *path,
   size_t len = 0;
   char *buf = malloc(cap);
   if (!buf) {
-#ifdef _WIN32
-    closesocket(sock);
-#else
-    close(sock);
-#endif
+    transport_close(ssl, ctx, sock);
     return -9;
   }
 
@@ -149,16 +206,12 @@ static int64_t http_perform(int64_t client_id, int64_t method, char *path,
       char *nb = realloc(buf, cap);
       if (!nb) {
         free(buf);
-#ifdef _WIN32
-        closesocket(sock);
-#else
-        close(sock);
-#endif
+        transport_close(ssl, ctx, sock);
         return -9;
       }
       buf = nb;
     }
-    ssize_t n = recv(sock, buf + len, CHUNK_SIZE, 0);
+    ssize_t n = transport_recv(ssl, sock, buf + len, CHUNK_SIZE);
     if (n > 0) {
       len += (size_t)n;
     } else {
@@ -166,11 +219,7 @@ static int64_t http_perform(int64_t client_id, int64_t method, char *path,
     }
   }
 
-#ifdef _WIN32
-  closesocket(sock);
-#else
-  close(sock);
-#endif
+  transport_close(ssl, ctx, sock);
 
   if (len == 0) {
     free(buf);
@@ -181,6 +230,58 @@ static int64_t http_perform(int64_t client_id, int64_t method, char *path,
   *out_raw = buf;
   *out_len = len;
   return 0;
+}
+
+// header_is_chunked reports whether the response header block declares
+// Transfer-Encoding: chunked (case-insensitive header name).
+static bool header_is_chunked(const char *headers) {
+  if (!headers) {
+    return false;
+  }
+  for (const char *p = headers; *p; p++) {
+    if ((p[0] == 'T' || p[0] == 't') &&
+        strncasecmp(p, "Transfer-Encoding:", 18) == 0) {
+      const char *v = p + 18;
+      return strstr(v, "chunked") != NULL || strstr(v, "Chunked") != NULL;
+    }
+  }
+  return false;
+}
+
+// decode_chunked decodes an HTTP/1.1 chunked body in place: each chunk is
+// "<hex-length>\r\n<data>\r\n", terminated by a zero-length chunk. Returns a
+// freshly allocated, NUL-terminated decoded body (caller frees), or NULL.
+static char *decode_chunked(const char *body) {
+  size_t cap = strlen(body) + 1;
+  char *out = malloc(cap);
+  if (!out) {
+    return NULL;
+  }
+  size_t out_len = 0;
+  const char *p = body;
+  for (;;) {
+    char *end = NULL;
+    long chunk = strtol(p, &end, 16); // chunk size in hex
+    if (end == p) {
+      break; // no valid size: stop
+    }
+    const char *line_end = strstr(end, "\r\n");
+    if (!line_end) {
+      break;
+    }
+    const char *data = line_end + 2;
+    if (chunk <= 0) {
+      break; // terminating zero chunk
+    }
+    memcpy(out + out_len, data, (size_t)chunk);
+    out_len += (size_t)chunk;
+    p = data + chunk;
+    if (strncmp(p, "\r\n", 2) == 0) {
+      p += 2; // skip trailing CRLF after the chunk data
+    }
+  }
+  out[out_len] = '\0';
+  return out;
 }
 
 // parse_status_line returns the numeric status from an HTTP status line, or -8.
@@ -284,7 +385,14 @@ int64_t http_request_capture(int64_t client_id, int64_t method, char *path,
     }
   }
 
-  char *resp_body = strdup(body_start);
+  // Decode a chunked body so callers see the real payload, not chunk framing.
+  char *resp_body = NULL;
+  if (header_is_chunked(resp_headers)) {
+    resp_body = decode_chunked(body_start);
+  }
+  if (!resp_body) {
+    resp_body = strdup(body_start);
+  }
   free(raw);
 
   if (!resp_body) {

--- a/compiler/runtime/http_shared.c
+++ b/compiler/runtime/http_shared.c
@@ -70,16 +70,20 @@ int parse_url(const char *url, char **host, int *port, char **path) {
     return -1;
   }
 
-  // Parse URL: http://host:port/path
+  // Parse URL: scheme://host:port/path. Track whether the scheme is a TLS one
+  // so an unspecified port defaults to 443 instead of 80.
   const char *start = url;
+  bool secure = false;
   if (strncmp(url, "http://", 7) == 0) {
     start += 7;
   } else if (strncmp(url, "https://", 8) == 0) {
     start += 8;
+    secure = true;
   } else if (strncmp(url, "ws://", 5) == 0) {
     start += 5;
   } else if (strncmp(url, "wss://", 6) == 0) {
     start += 6;
+    secure = true;
   }
 
   // Find host end
@@ -95,7 +99,7 @@ int parse_url(const char *url, char **host, int *port, char **path) {
     }
   } else {
     host_len = slash ? slash - start : (int)strlen(start);
-    *port = 80; // Default port
+    *port = secure ? 443 : 80; // Default port by scheme
   }
 
   if (host_len <= 0) {

--- a/compiler/runtime/http_shared.h
+++ b/compiler/runtime/http_shared.h
@@ -81,6 +81,7 @@ typedef struct {
   char *host;
   int port;
   bool is_persistent;
+  bool is_https; // true when the base URL scheme is https:// (use TLS)
 } HttpClient;
 
 // WebSocket connection structure

--- a/compiler/runtime/term_runtime.c
+++ b/compiler/runtime/term_runtime.c
@@ -25,6 +25,13 @@ static bool g_raw_active = false;
 #define ANSI_SHOW_CURSOR "\x1b[?25h"
 #define ANSI_HIDE_CURSOR "\x1b[?25l"
 #define ANSI_CLEAR "\x1b[2J\x1b[H"
+// Alternate screen buffer (what vim/htop/less use): a separate, no-scrollback
+// surface. Entering it gives a clean canvas where clear+home redraws truly in
+// place; leaving it restores the user's previous terminal contents verbatim.
+#define ANSI_ALT_SCREEN_ON "\x1b[?1049h"
+#define ANSI_ALT_SCREEN_OFF "\x1b[?1049l"
+
+static bool g_alt_screen = false;
 
 static void restore_terminal(void) {
   if (g_orig_saved && g_raw_active) {
@@ -32,12 +39,18 @@ static void restore_terminal(void) {
     g_raw_active = false;
   }
   fputs(ANSI_SHOW_CURSOR, stdout);
+  if (g_alt_screen) {
+    fputs(ANSI_ALT_SCREEN_OFF, stdout);
+    g_alt_screen = false;
+  }
   fflush(stdout);
 }
 
-// term_raw_mode(1) enables raw mode (no canonical line buffering, no echo);
-// term_raw_mode(0) restores cooked mode. ISIG stays enabled so Ctrl-C always
-// terminates and the atexit handler can never leave the terminal stuck.
+// term_raw_mode(1) enables raw mode (no canonical line buffering, no echo) and
+// switches to the alternate screen buffer so the TUI redraws in place without
+// piling frames into scrollback; term_raw_mode(0) restores cooked mode and the
+// original screen. ISIG stays enabled so Ctrl-C always terminates and the atexit
+// handler can never leave the terminal stuck.
 int64_t term_raw_mode(int64_t on) {
   if (on) {
     if (!g_orig_saved) {
@@ -55,6 +68,10 @@ int64_t term_raw_mode(int64_t on) {
       return -2;
     }
     g_raw_active = true;
+    fputs(ANSI_ALT_SCREEN_ON, stdout);
+    fputs(ANSI_CLEAR, stdout);
+    fflush(stdout);
+    g_alt_screen = true;
     return 0;
   }
   if (g_orig_saved) {
@@ -63,6 +80,11 @@ int64_t term_raw_mode(int64_t on) {
     }
   }
   g_raw_active = false;
+  if (g_alt_screen) {
+    fputs(ANSI_ALT_SCREEN_OFF, stdout);
+    fflush(stdout);
+    g_alt_screen = false;
+  }
   return 0;
 }
 


### PR DESCRIPTION
<!-- agent-pmo:74cf183 -->
## TLDR
Add real HTTPS/TLS to the HTTP client and an alternate-screen terminal mode, rewrite the TUI demo as a fully algebraic-effects program, and fix the four Hindley-Milner/codegen gaps that made an effect-based `Result`-returning program impossible to express.

## Details

**HTTPS/TLS client (C runtime)** — `compiler/runtime/http_client_runtime.c`, `http_shared.{c,h}`
- `https://`/`wss://` clients now negotiate TLS via OpenSSL: `transport_send`/`transport_recv`/`transport_close` route over `SSL_*` when the client is secure, over the bare socket otherwise, so one `http_perform` serves both schemes.
- SNI (`SSL_set_tlsext_host_name`) is set — required by virtual-hosted endpoints like `api.github.com`.
- `parse_url` defaults the port to 443 for TLS schemes (was always 80); `HttpClient` gains `is_https`.
- The `Host` header now omits `:port` (GitHub returns 400 for `Host: api.github.com:443`).

**Alternate-screen terminal (C runtime)** — `compiler/runtime/term_runtime.c`
- `term_raw_mode(1)` enters the alternate screen buffer (`\x1b[?1049h`) and clears; `term_raw_mode(0)` and the `atexit` restore handler leave it (`\x1b[?1049l`), so the TUI redraws in place and restores the user's scrollback on exit.

**Type inference & codegen (Go)** — `internal/codegen/{type_inference,function_signatures,llvm,effects_generation}.go`
- *`Result<T,E>` as a parameter* (previously auto-unwrapped to `T`): `maybeUnwrapArg`/`isResultType` suppress the Result auto-unwrap when the parameter is itself a `Result`; codegen mirrors it (`calleeParamIsResult`) and `coerceArgumentToParamType` loads an alloca'd Result into a by-value struct parameter. `fibonacci(n - 1)` still auto-unwraps.
- *`Error { … }` / `Success { … }` construction*: `inferTypeConstructor` now types `Error { message }` as `Result<'a, Error>` (concrete `Error` error type) and `Success { value }` with a polymorphic error type, instead of pinning the error slot to the message/`string` type — so a function annotated `Result<string, Error>` can construct either variant.
- *Error-message propagation*: the `Error { message }` match arm binds `message` to the real Result payload (`bindResultPayload`) instead of a static `"Error occurred"` stand-in (kept only as a fallback for non-string payloads such as `Result<int, E>`).
- *Forward references*: `preDeclareFunctionPlaceholder` carries explicit param/return annotations instead of bare type variables, so calling a `Result`-returning function declared later in the file resolves its return type.
- *Struct-by-value returns*: `coerceReturnToRetType` (and the effect-handler return path) load a pointer-to-struct before `ret`, so a function/handler returning a `Result` emits `ret {ptr,i8}` (value) rather than `ret {ptr,i8}*`, which strict `llc` rejects.

**Example** — `compiler/examples/tui/api_browser.osp`
- Rewritten as a fully algebraic-effects TUI: `Console.print`, `Terminal.readKey`/`raw`, and `Http.fetch` effects, with handlers installed in `main`. The UI logic only `perform`s — zero local bindings, no I/O primitives — and the entire client/response lifecycle is hidden in the `Http` handler.

**Build & tooling**
- `make tui` (root + compiler) rebuilds and launches the demo on a real stdin for the raw-mode key reader.
- `make vsix` now stages the freshly-built compiler into the extension (`_vsix_bundle`) so LSP diagnostics run against it, not a stale global `osprey`; `.vscode/settings.json` points `osprey.server.compilerPath` at the dev binary.

## How Do The Automated Tests Prove It Works?
- `tests/integration.TestEffectsExamples` and `TestHTTPExamples` compile **and run** every program under `examples/tested/effects` and `examples/tested/http`, asserting stdout byte-for-byte against each `.expectedoutput` — exercising the effect handlers, `Result` construction/matching, and the struct-by-value return/argument codegen end to end.
- `tests/integration.TestCompilationFailures` asserts exact compiler error text for `examples/failscompilation/**`; `union_type_mismatch.ospo.expectedoutput` is updated for the new (equivalent) fresh-var label produced after the forward-reference signature change.
- `tests/unit/codegen` covers `Result` construction, pattern matching, and function-return code generation directly.
- `tests/integration.TestHTTPRuntimeLibrary` / `TestPkgConfigOpenSSL` and the C runtime suite (`make c-test`) verify the HTTP transport and OpenSSL linkage.
- Manual end-to-end: `make tui` performs a live HTTPS GET to the GitHub REST API and renders the repository list (e.g. `osprey ★46 Go`, `dart_node ★112 Dart`), then exits cleanly via the `Terminal`/`Console` handlers on EOF.
