### PR TITLE
docs(blog): fix outdated Osprey syntax + skip heavy CI for website-only PRs

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -5,6 +5,12 @@ name: CI (Windows)
 on:
   pull_request:
     branches: [main]
+    # Website-only PRs don't touch the compiler — skip the Windows build entirely.
+    # windows-core is NOT a required status check, so skipping the whole workflow
+    # via path filtering here is safe and won't leave a pending check blocking the
+    # merge. (ci.yml's required `ci` job uses job-level `if` skipping instead.)
+    paths-ignore:
+      - 'website/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ─── Change detection ───────────────────────────────────────────────────────
+  # Website-only PRs (changes confined to website/**) don't need the compiler, C
+  # runtime, VS Code extension or web-compiler toolchain. Detect whether anything
+  # OUTSIDE website/ changed so the heavy jobs below can skip.
+  #
+  # Required-check note: the `ci` job ("Test, Format, Build & Validate") is the
+  # required status check on `main` (ruleset 6154907). Skipping a job via an `if:`
+  # condition reports its check as "skipped", which branch protection treats as
+  # PASSING — so a website-only PR still merges. Do NOT convert this to an
+  # `on: paths:` filter: a workflow skipped by path filtering leaves the required
+  # check pending forever and blocks the merge.
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      website: ${{ steps.filter.outputs.website }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            website:
+              - 'website/**'
+            code:
+              - '!website/**'
+
   ci:
     # IMPORTANT: this name is the required status check on `main` (ruleset 6154907).
     # Renaming it will break branch protection — coordinate with the ruleset update.
     name: Test, Format, Build & Validate
+    needs: changes
+    # Skip the full compiler/runtime/extension pipeline for website-only PRs.
+    # A skipped required check reports as passing (see the `changes` job note).
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     # TIMEOUT EXCEPTION: full compiler build + C runtime compile + extension
     # tests + Docker web compiler test requires ~15 min
@@ -124,6 +157,9 @@ jobs:
   # (examples/failscompilation) must stay within the FC_EXPECTED_ESCAPES ratchet.
   rust:
     name: Rust Compiler (fmt, clippy, test, differential)
+    needs: changes
+    # Compiler-only gate — irrelevant to website-only PRs, so skip them.
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/website/src/blog/2025-01-10-building-web-apis-with-pattern-matching.md
+++ b/website/src/blog/2025-01-10-building-web-apis-with-pattern-matching.md
@@ -40,284 +40,155 @@ app.post('/users', async (req, res) => {
 
 ## Modeling API Responses with Algebraic Data Types
 
-Osprey takes a different approach. We model all possible outcomes as **algebraic data types**:
+Osprey takes a different approach. We model all possible outcomes as a single **algebraic data type** — a union whose variants each carry their own record of fields:
 
 ```osprey
-type CreateUserResult = 
-  | Success(user: User, id: UserId)
-  | ValidationError(fields: List<String>, messages: List<String>)
-  | DuplicateEmail(email: String)
-  | DatabaseTimeout(retryAfter: Int)
-  | DatabaseError(message: String)
-  | InternalError(context: String)
-
-type ApiResponse<T> = 
-  | Ok(data: T, status: Int)
-  | Error(message: String, code: String, status: Int)
+type CreateUserResult =
+    Created            { user: User, id: UserId }
+    | ValidationFailed { fields: List<string>, messages: List<string> }
+    | DuplicateEmail   { email: string }
+    | DatabaseTimeout  { retryAfter: int }
+    | DatabaseFailure  { message: string }
+    | InternalFailure  { context: string }
 ```
 
-Now our API handler **must** handle every case:
+Now our API handler **must** handle every case. A small helper keeps each arm to a single line — `HttpResponse` is Osprey's built-in response record:
 
 ```osprey
-fn createUserHandler(request: HttpRequest) -> HttpResponse {
-  let userData = parseUserData(request.body)
-  
-  match createUser(userData) {
-    Success(user, id) -> 
-      Ok({ user: user, id: id }, 201),
-      
-    ValidationError(fields, messages) ->
-      Error(
-        "Validation failed: " + messages.join(", "),
-        "VALIDATION_ERROR",
-        400
-      ),
-      
-    DuplicateEmail(email) ->
-      Error(
-        "Email " + email + " is already registered",
-        "DUPLICATE_EMAIL", 
-        409
-      ),
-      
-    DatabaseTimeout(retryAfter) ->
-      Error(
-        "Database temporarily unavailable",
-        "DATABASE_TIMEOUT",
-        503
-      ).withHeader("Retry-After", retryAfter.toString()),
-      
-    DatabaseError(message) ->
-      Error(
-        "Database error occurred",
-        "DATABASE_ERROR",
-        502
-      ).withLogging("Database error: " + message),
-      
-    InternalError(context) ->
-      Error(
-        "Internal server error",
-        "INTERNAL_ERROR",
-        500
-      ).withLogging("Internal error in " + context)
-  }
+fn json(status: int, body: string) -> HttpResponse = HttpResponse {
+    status: status,
+    headers: "Content-Type: application/json",
+    contentType: "application/json",
+    streamFd: -1,
+    isComplete: true,
+    partialBody: body
 }
+
+fn createUserHandler(request: HttpRequest) -> HttpResponse =
+    match createUser(parseUserData(request.body)) {
+        Created { user, id } =>
+            json(201, "{\"id\": ${toString(id)}}")
+        ValidationFailed { fields, messages } =>
+            json(400, "{\"error\": \"validation failed\"}")
+        DuplicateEmail { email } =>
+            json(409, "{\"error\": \"${email} is already registered\"}")
+        DatabaseTimeout { retryAfter } =>
+            json(503, "{\"error\": \"retry after ${toString(retryAfter)}s\"}")
+        DatabaseFailure { message } =>
+            json(502, "{\"error\": \"database error\"}")
+        InternalFailure { context } =>
+            json(500, "{\"error\": \"internal error in ${context}\"}")
+    }
 ```
 
-**The compiler guarantees** you handle every case. If you add a new error type, every pattern match that handles `CreateUserResult` will fail to compile until you add the new case.
+**The compiler guarantees** you handle every case. If you add a new variant to `CreateUserResult`, every `match` that handles it will fail to compile until you add the new arm.
 
-## Building a Complete REST API
+## Building a Complete User API
 
-Let's build a complete user management API to see how this scales:
+Let's build out a user management API to see how this scales. Osprey has no `module` keyword yet — types and functions live at the top level. Each operation returns a domain union, so the caller is forced to handle every outcome:
 
 ```osprey
-module UserApi {
-  type User = {
-    id: UserId,
-    email: String,
-    name: String,
-    createdAt: DateTime,
-    isActive: Boolean
-  }
-  
-  type UserFilter = 
-    | All
-    | Active
-    | Inactive
-    | CreatedAfter(date: DateTime)
-    | EmailDomain(domain: String)
-  
-  type UserOperation<T> = 
-    | Success(data: T)
-    | NotFound(id: UserId)
-    | ValidationError(field: String, message: String)
-    | PermissionDenied(action: String)
-    | DatabaseError(details: String)
-    | RateLimited(resetTime: DateTime)
-  
-  // GET /users
-  fn listUsers(filter: UserFilter, auth: AuthToken) -> UserOperation<List<User>> {
-    if (!auth.hasPermission("users:read")) {
-      return PermissionDenied("list users")
+type User = { id: int, email: string, name: string, isActive: bool }
+
+type UserFilter = All | Active | Inactive | EmailDomain { domain: string }
+
+type UserQuery =
+    Found       { user: User }
+    | Missing     { id: int }
+    | Forbidden   { action: string }
+    | QueryFailed { details: string }
+
+// GET /users/:id — permission gating is just another match arm.
+// Osprey is expression-based, so there is no early `return`.
+fn getUser(id: int, auth: AuthToken) -> UserQuery =
+    match hasPermission(auth, "users:read") {
+        false => Forbidden { action: "read user" }
+        true  => lookupUser(id)
     }
-    
-    match Database.queryUsers(filter) {
-      Ok(users) -> Success(users),
-      Err(dbError) -> DatabaseError(dbError.toString())
-    }
-  }
-  
-  // GET /users/:id
-  fn getUser(id: UserId, auth: AuthToken) -> UserOperation<User> {
-    if (!auth.hasPermission("users:read")) {
-      return PermissionDenied("read user")
-    }
-    
-    match Database.findUser(id) {
-      Some(user) -> Success(user),
-      None -> NotFound(id)
-    }
-  }
-  
-  // PUT /users/:id
-  fn updateUser(id: UserId, updates: UserUpdates, auth: AuthToken) -> UserOperation<User> {
-    if (!auth.hasPermission("users:write")) {
-      return PermissionDenied("update user")
-    }
-    
-    match validateUserUpdates(updates) {
-      Invalid(field, message) -> ValidationError(field, message),
-      Valid(validUpdates) -> 
-        match Database.updateUser(id, validUpdates) {
-          Some(updatedUser) -> Success(updatedUser),
-          None -> NotFound(id)
+```
+
+Validation and lookup compose as nested matches. The built-in `Result<T, E>` type (whose variants are `Success` and `Error`) threads naturally into our domain union:
+
+```osprey
+// PUT /users/:id
+fn updateUser(id: int, updates: UserUpdates, auth: AuthToken) -> UserQuery =
+    match hasPermission(auth, "users:write") {
+        false => Forbidden { action: "update user" }
+        true  => match validate(updates) {
+            Error   { message } => QueryFailed { details: message }
+            Success { value }   => applyUpdate(id, value)
         }
     }
-  }
-}
 ```
 
 ## HTTP Response Conversion
 
-Converting our domain types to HTTP responses becomes a pure mapping function:
+Converting our domain types to HTTP responses becomes a pure mapping function that reuses the `json` helper from earlier:
 
 ```osprey
-fn toHttpResponse<T>(operation: UserOperation<T>, encoder: T -> Json) -> HttpResponse {
-  match operation {
-    Success(data) -> 
-      HttpResponse(200, encoder(data)),
-      
-    NotFound(id) ->
-      HttpResponse(404, {
-        error: "User not found",
-        code: "USER_NOT_FOUND", 
-        userId: id.toString()
-      }),
-      
-    ValidationError(field, message) ->
-      HttpResponse(400, {
-        error: "Validation failed",
-        code: "VALIDATION_ERROR",
-        field: field,
-        message: message
-      }),
-      
-    PermissionDenied(action) ->
-      HttpResponse(403, {
-        error: "Permission denied",
-        code: "PERMISSION_DENIED",
-        action: action
-      }),
-      
-    DatabaseError(details) ->
-      HttpResponse(500, {
-        error: "Internal server error",
-        code: "DATABASE_ERROR"
-      }).withLogging("DB Error: " + details),
-      
-    RateLimited(resetTime) ->
-      HttpResponse(429, {
-        error: "Rate limit exceeded", 
-        code: "RATE_LIMITED"
-      }).withHeader("X-Rate-Limit-Reset", resetTime.toIsoString())
-  }
+fn toHttpResponse(q: UserQuery) -> HttpResponse = match q {
+    Found { user }          => json(200, "{\"email\": \"${user.email}\"}")
+    Missing { id }          => json(404, "{\"error\": \"user ${toString(id)} not found\"}")
+    Forbidden { action }    => json(403, "{\"error\": \"permission denied: ${action}\"}")
+    QueryFailed { details } => json(500, "{\"error\": \"internal error\"}")
 }
 ```
 
 ## Request Routing with Pattern Matching
 
-Osprey's pattern matching shines for request routing too:
+Osprey matches a single value per `match`, so multi-key routing is expressed as **nested matches** rather than tuple patterns:
 
 ```osprey
-fn routeRequest(request: HttpRequest) -> HttpResponse {
-  match (request.method, request.path, request.auth) {
-    (GET, "/users", Some(auth)) ->
-      let filter = parseUserFilter(request.query)
-      UserApi.listUsers(filter, auth) |> toHttpResponse(encodeUserList),
-      
-    (GET, "/users/" + userId, Some(auth)) ->
-      match UserId.parse(userId) {
-        Some(id) -> UserApi.getUser(id, auth) |> toHttpResponse(encodeUser),
-        None -> HttpResponse(400, { error: "Invalid user ID" })
-      },
-      
-    (PUT, "/users/" + userId, Some(auth)) ->
-      match (UserId.parse(userId), parseUserUpdates(request.body)) {
-        (Some(id), Some(updates)) -> 
-          UserApi.updateUser(id, updates, auth) |> toHttpResponse(encodeUser),
-        (None, _) -> 
-          HttpResponse(400, { error: "Invalid user ID" }),
-        (_, None) -> 
-          HttpResponse(400, { error: "Invalid request body" })
-      },
-      
-    (_, _, None) ->
-      HttpResponse(401, { error: "Authentication required" }),
-      
-    (method, path, _) ->
-      HttpResponse(404, { 
-        error: "Endpoint not found",
-        method: method.toString(),
-        path: path 
-      })
-  }
-}
+fn routeRequest(method: string, path: string, auth: AuthToken) -> HttpResponse =
+    match method {
+        "GET" => match path {
+            "/health" => json(200, "{\"status\": \"ok\"}")
+            "/users"  => toHttpResponse(getUser(1, auth))
+            _         => json(404, "{\"error\": \"not found\"}")
+        }
+        "POST" => json(201, "{\"message\": \"created\"}")
+        _      => json(405, "{\"error\": \"method not allowed\"}")
+    }
 ```
 
 ## Middleware as Function Composition
 
-Middleware becomes simple function composition:
+Functions are first-class, so middleware is just a function that wraps a handler. The `next` parameter is the handler to run if the gate passes — again, no early return, the gate is simply a `match`:
 
 ```osprey
-fn withRateLimit<T>(handler: HttpRequest -> T, limit: RateLimit) -> HttpRequest -> UserOperation<T> {
-  fn(request) {
-    match RateLimit.check(request.clientIp, limit) {
-      Allowed -> Success(handler(request)),
-      Limited(resetTime) -> RateLimited(resetTime)
+fn withAuth(
+    auth: AuthToken,
+    action: string,
+    next: fn(AuthToken) -> UserQuery
+) -> UserQuery =
+    match hasPermission(auth, action) {
+        false => Forbidden { action: action }
+        true  => next(auth)
     }
-  }
-}
-
-fn withAuth<T>(handler: (HttpRequest, AuthToken) -> T) -> HttpRequest -> UserOperation<T> {
-  fn(request) {
-    match Auth.validateToken(request.headers.authorization) {
-      Valid(token) -> Success(handler(request, token)),
-      Invalid -> PermissionDenied("invalid token"),
-      Missing -> PermissionDenied("authentication required")
-    }
-  }
-}
-
-// Compose middleware naturally
-let protectedHandler = listUsersHandler
-  |> withAuth
-  |> withRateLimit(RateLimit.perMinute(100))
 ```
+
+Because handlers are ordinary values, you compose cross-cutting concerns the same way you compose any other function — with the pipe operator `|>`.
 
 ## Testing Becomes Trivial
 
-Since everything is a pure function returning data, testing is incredibly straightforward:
+Since every handler is a pure function over data, testing is incredibly straightforward. Osprey programs are exercised with the **differential harness**: a program's `stdout` is byte-compared against a checked-in `.expectedoutput` file. A test is just a program that prints each outcome:
 
 ```osprey
-test "user creation handles all error cases" {
-  // Test successful creation
-  assert UserApi.createUser(validUserData) == Success(expectedUser, expectedId)
-  
-  // Test validation errors
-  assert UserApi.createUser(invalidEmail) == ValidationError(["email"], ["Invalid format"])
-  
-  // Test duplicate email
-  assert UserApi.createUser(duplicateEmail) == DuplicateEmail("test@example.com")
-  
-  // The compiler ensures we test every possible return value
+fn main() -> int {
+    print(describe(getUser(1, adminAuth)))   // Found ...
+    print(describe(getUser(2, adminAuth)))   // Forbidden ...
+    print(describe(getUser(9, adminAuth)))   // Missing ...
+    0
 }
 ```
+
+Because the result of each call is plain data, the expected output is completely deterministic — there is no hidden state to mock.
 
 ## The Reliability Advantage
 
 This approach eliminates entire categories of production bugs:
 
-- **No null reference exceptions** - Options and Results make nullability explicit
+- **No null reference exceptions** - Absence is modelled explicitly with union variants
 - **No unhandled error cases** - Pattern matching forces you to handle every scenario  
 - **No silent failures** - Every operation's outcome is explicitly modeled
 - **No incorrect status codes** - HTTP responses are generated deterministically
@@ -325,16 +196,18 @@ This approach eliminates entire categories of production bugs:
 
 ## Performance Benefits
 
-Despite the high-level abstractions, Osprey compiles to efficient code:
+Despite the high-level abstractions, Osprey compiles to efficient code. Functional pipelines over ranges are fused into a single loop:
 
 ```osprey
-// This high-level code...
-let result = users
-  |> filter(u -> u.isActive)
-  |> map(u -> { ...u, lastSeen: now() })
-  |> take(10)
+fn add(a: int, b: int) -> int = a + b
 
-// ...compiles to an efficient loop with no intermediate allocations
+// This high-level code...
+let result = range(1, 1000)
+    |> filter(fn(n: int) => (n % 2) == 0)
+    |> map(fn(n: int) => n * n)
+    |> fold(0, add)
+
+// ...compiles to a single loop with no intermediate lists (stream fusion).
 ```
 
 The pattern matching compiles to efficient jump tables, and the functional pipelines are optimized away entirely.
@@ -349,4 +222,6 @@ The functional programming revolution isn't coming—**it's here**. And for web 
 
 ---
 
-*Ready to try building your own type-safe APIs? Browse the [documentation](/docs/) or experiment in the [playground](/playground/).* 
+*Ready to try building your own type-safe APIs? Browse the [documentation](/docs/) or experiment in the [playground](/playground/).*
+
+> **Editor's note (updated 2026-06-20):** This post was first published in January 2025, early in Osprey's development. Osprey's syntax has evolved considerably since then — among other changes, the language settled on `=>` for match arms, record-style union variants, expression-bodied functions, lowercase primitive types (`int`/`string`/`bool`), and `Result` with `Success`/`Error`. The code samples above have been revised to match the current language. The original article is preserved unchanged in this site's Git history — browse the [repository](https://github.com/MelbourneDeveloper/osprey) and view this file's history to read it exactly as first published.

--- a/website/src/blog/2025-01-15-the-memory-safe-revolution.md
+++ b/website/src/blog/2025-01-15-the-memory-safe-revolution.md
@@ -18,12 +18,13 @@ This isn't just another trend—it's a fundamental shift that will reshape how w
 Traditional systems languages like C and C++ have powered our digital infrastructure for decades. But their flexibility comes with a devastating cost: **memory vulnerabilities are endemic**. Buffer overflows, use-after-free bugs, and null pointer dereferences aren't edge cases—they're the primary attack vectors compromising our most critical systems.
 
 ```osprey
-// In Osprey, this is impossible - the type system prevents null access
-fn processUser(user: User) -> Result<String, Error> {
-  match user.email {
-    Some(email) -> Ok("User has email: " + email),
-    None -> Err("User email not provided")
-  }
+// Osprey has no null. Absence is a value you must handle explicitly,
+// so "forgot to check for null" simply cannot happen.
+type Email = Provided { address: string } | Absent
+
+fn describeEmail(e: Email) -> string = match e {
+    Provided { address } => "User has email: ${address}"
+    Absent               => "User email not provided"
 }
 ```
 
@@ -41,35 +42,30 @@ While the memory safety crisis unfolds, functional programming is experiencing u
 
 ### **Immutability by Default**
 ```osprey
-// Osprey makes immutability natural and efficient
-let users = [
-  { name: "Alice", age: 30 },
-  { name: "Bob", age: 25 }
-]
+type User = { name: string, age: int, status: string }
 
-// This creates a new list without mutating the original
-let adults = users
-  |> filter(u -> u.age >= 18)
-  |> map(u -> { ...u, status: "verified" })
+let alice = User { name: "Alice", age: 30, status: "new" }
+
+// Record "update" returns a NEW value — alice is untouched.
+let verified = alice { status: "verified" }
+
+// Persistent collections behave the same way. listAppend returns a new
+// list that shares structure with the old one; nothing is mutated.
+let base = listAppend(listAppend(List(), alice), verified)
+let more = listAppend(base, alice { name: "Bob", age: 25 })
+// base still has length 2; `more` has length 3.
 ```
 
 ### **Fearless Concurrency**
-In Osprey, our **fiber-based concurrency model** makes parallel programming intuitive:
+In Osprey, our **fiber-based concurrency model** makes parallel programming intuitive. Fibers are spawned with `spawn { ... }` and joined with `await(...)`:
 
 ```osprey
-// Launch multiple async operations that can't cause data races
-fn fetchUserData(userId: String) -> Fiber<UserProfile> {
-  fiber {
-    let profile = fetch("/api/users/" + userId)
-    let preferences = fetch("/api/preferences/" + userId)
-    let activity = fetch("/api/activity/" + userId)
-    
-    UserProfile {
-      profile: profile.await,
-      preferences: preferences.await,
-      activity: activity.await
-    }
-  }
+// Launch isolated async operations that can't cause data races.
+fn fetchUserData(userId: int) -> int ![Logger] = {
+    let profile     = spawn { fetchProfile(userId) }
+    let preferences = spawn { fetchPreferences(userId) }
+    let activity    = spawn { fetchActivity(userId) }
+    await(profile) + await(preferences) + await(activity)
 }
 ```
 
@@ -84,17 +80,16 @@ Most modern languages adopted async/await as their concurrency solution. But as 
 Research from functional programming communities shows a clear alternative: **structured concurrency with lightweight threads**. This is exactly what Osprey's fiber system provides.
 
 ```osprey
-// Structured concurrency ensures all child operations complete
-fn processUsers(users: List<User>) -> Result<List<ProcessedUser>, Error> {
-  fiberGroup {
-    users.map(user -> 
-      fiber { processUserData(user) }
-    )
-  }.awaitAll()
+// Structured concurrency: spawn child fibers, then await each result.
+fn processBatch() -> int ![Logger] = {
+    let a = spawn { processOne(1) }
+    let b = spawn { processOne(2) }
+    let c = spawn { processOne(3) }
+    await(a) + await(b) + await(c)
 }
 ```
 
-When a `fiberGroup` exits, all child fibers are automatically canceled if they haven't completed. No orphaned operations, no resource leaks.
+Fibers are isolated execution contexts that communicate by message passing rather than shared memory — so there are no orphaned operations sharing mutable state behind your back.
 
 ## The Enterprise Shift is Already Happening
 
@@ -108,7 +103,7 @@ Major tech companies are making the transition:
 But here's what's missing: most memory-safe languages sacrifice either **performance** or **expressiveness**. Rust achieves memory safety but has a notoriously steep learning curve. Go prioritizes simplicity but lacks advanced type system features.
 
 **Osprey bridges this gap** by combining:
-- **Memory safety** through ownership and borrowing
+- **Memory safety** without manual memory management
 - **Functional expressiveness** with pattern matching and type inference  
 - **Zero-cost abstractions** that compile to efficient native code
 - **Modern concurrency** with structured fiber programming
@@ -118,22 +113,20 @@ But here's what's missing: most memory-safe languages sacrifice either **perform
 One of Osprey's most powerful features is its **exhaustive pattern matching** system:
 
 ```osprey
-type HttpResponse = 
-  | Success(data: Json, status: Int)
-  | ClientError(message: String, status: Int)
-  | ServerError(message: String, status: Int)
-  | NetworkError(timeout: Boolean)
+type ApiResult =
+    Body          { data: string, status: int }
+    | ClientError { message: string, status: int }
+    | ServerError { message: string }
+    | NetworkDown { timedOut: bool }
 
-fn handleResponse(response: HttpResponse) -> String {
-  match response {
-    Success(data, 200) -> "OK: " + data.toString(),
-    Success(data, status) -> "Success with status " + status.toString(),
-    ClientError(msg, 404) -> "Not found: " + msg,
-    ClientError(msg, status) -> "Client error " + status.toString() + ": " + msg,
-    ServerError(msg, _) -> "Server error: " + msg,
-    NetworkError(true) -> "Request timed out",
-    NetworkError(false) -> "Network connection failed"
-  }
+fn handleResponse(r: ApiResult) -> string = match r {
+    Body { data, status }           => "${toString(status)} OK: ${data}"
+    ClientError { message, status } => "client ${toString(status)}: ${message}"
+    ServerError { message }         => "server error: ${message}"
+    NetworkDown { timedOut }        => match timedOut {
+        true  => "request timed out"
+        false => "network connection failed"
+    }
 }
 ```
 
@@ -143,50 +136,50 @@ The compiler **guarantees** you handle every case. No null pointer exceptions, n
 
 Memory safety typically comes with runtime overhead—garbage collection pauses, reference counting costs, or dynamic checks. **Osprey takes a different approach**:
 
-Our **compile-time ownership analysis** eliminates most runtime safety checks while providing **zero-cost abstractions**. When you write high-level functional code, the compiler generates efficient imperative machine code.
+Compile-time analysis eliminates most runtime safety checks while providing **zero-cost abstractions**. When you write high-level functional code, the compiler generates efficient imperative machine code.
 
 ```osprey
-// High-level functional code...
-let result = numbers
-  |> filter(n -> n > 0)
-  |> map(n -> n * 2)  
-  |> reduce(0, (+))
+fn add(a: int, b: int) -> int = a + b
 
-// ...compiles to efficient loops with no allocations
+// High-level functional code...
+let result = range(1, 100)
+    |> filter(fn(n: int) => n > 0)
+    |> map(fn(n: int) => n * 2)
+    |> fold(0, add)
+
+// ...compiles to a single fused loop with no intermediate lists.
 ```
 
 ## What Makes Osprey Different
 
-### **Module System with Isolation**
-Osprey's module system prevents the kind of global state issues that plague large codebases:
+### **Immutable State, No Hidden Globals**
+Osprey threads state explicitly as immutable values instead of hiding it in mutable globals — exactly the kind of shared state that plagues large codebases. A cache is just an immutable `Map` passed in and returned:
 
 ```osprey
-module UserService {
-  private let cache = LRUCache.new<String, User>(1000)
-  
-  export fn getUser(id: String) -> Result<User, Error> {
-    match cache.get(id) {
-      Some(user) -> Ok(user),
-      None -> {
-        let user = Database.fetchUser(id)?
-        cache.set(id, user)
-        Ok(user)
-      }
+fn cachedName(id: string, cache: Map<string, string>) -> string =
+    match cache[id] {
+        Success { value }   => value
+        Error   { message } => "miss"
     }
-  }
-}
+
+// Growing the cache returns a NEW map — old versions stay valid.
+let c1 = mapSet(Map(), "u1", "Alice")
+let c2 = mapSet(c1, "u2", "Bob")
 ```
 
 ### **Effect System for Controlled Side Effects**
-Not all operations are pure, but Osprey's effect system makes side effects **explicit and controllable**:
+Not all operations are pure, but Osprey's effect system makes side effects **explicit and controllable**. Effects are declared in the signature with `![...]` and performed with `perform`; a handler decides what they actually do:
 
 ```osprey
-fn saveUser(user: User) -> IO<Result<UserId, DatabaseError>> {
-  io {
-    let validation = validateUser(user)  // Pure function
-    let saved = Database.insert(user)?   // Effectful operation
-    Ok(saved.id)
-  }
+effect Db {
+    insert: fn(User) -> int
+}
+
+fn saveUser(user: User) -> int ![Db, Logger] = {
+    perform Logger.log("validating user")
+    let id = perform Db.insert(user)
+    perform Logger.log("saved ${toString(id)}")
+    id
 }
 ```
 
@@ -207,4 +200,6 @@ The question isn't whether the industry will adopt memory-safe functional langua
 
 ---
 
-*Want to try Osprey yourself? Check out our [interactive playground](/playground/) or dive into the [documentation](/docs/) to get started.* 
+*Want to try Osprey yourself? Check out our [interactive playground](/playground/) or dive into the [documentation](/docs/) to get started.*
+
+> **Editor's note (updated 2026-06-20):** This post was first published in January 2025, early in Osprey's development. Osprey's syntax has evolved considerably since then — among other changes, the language dropped `Option`/`Some`/`None` in favour of explicit union variants, settled on `spawn`/`await(...)` for fibers, `=>` for match arms, expression-bodied functions, and lowercase primitive types (`int`/`string`/`bool`). The code samples above have been revised to match the current language. The original article is preserved unchanged in this site's Git history — browse the [repository](https://github.com/MelbourneDeveloper/osprey) and view this file's history to read it exactly as first published.


### PR DESCRIPTION
## TLDR
Fix outdated/incorrect Osprey syntax in the two January-2025 blog posts, and make CI skip the heavy compiler/runtime checks for website-only PRs.

## Details

**Blog syntax corrections** (`website/src/blog/2025-01-10-…md`, `…2025-01-15-…md`)
The code samples in both posts described a language that never shipped in that form. Rewrote every snippet to compile against current Osprey:
- `=>` match arms (was `->` with commas)
- record-style union variants `Created { user, id }` (was tuple-style `Success(user, id)`)
- expression-bodied functions `fn f(...) -> T = …` (was C-style `{ return … }`)
- lowercase primitives `int` / `string` / `bool` (was `Int` / `String` / `Boolean`)
- `spawn { … }` + `await(f)` fibers (was `fiber { … }` + `.await`)
- `perform` / `handle … in` effects with `![Effect]` signatures
- `Result` with `Success` / `Error` (dropped the non-existent `Option`/`Some`/`None`, `module`, `test`/`assert` blocks, tuple patterns, and `{ ...spread }`)

Each corrected snippet pattern was compiled and run with `target/release/osprey` first; patterns that currently crash the compiler (e.g. `Result<T, userUnion>` with record payloads, list-of-records pipelines) were deliberately avoided. Each post gets an **editor's note** explaining the syntax has evolved over time and linking the original via the repo's Git history. The 2026 persistent-collections post already used current syntax and is left untouched.

**CI: skip compiler checks for website-only PRs**
- `ci.yml`: new `changes` detection job (`dorny/paths-filter`) outputs whether anything outside `website/**` changed. The heavy `ci` (the required status check) and `rust` jobs are now gated on `code == 'true'`. Skipping via a job-level `if:` reports the required check as **skipped → passing**, so a website-only PR still merges — a workflow-level `on: paths:` filter would instead leave the required check pending forever and block the merge. The `website` Playwright job still runs.
- `ci-windows.yml`: `paths-ignore: ['website/**']` skips the Windows build on website-only PRs (not a required check).

## How Do The Automated Tests Prove It Works?
- **Website E2E (Playwright): 68/68 passed**, including the blog-post assertions — `tests/pages.spec.js` `page: blog-post › loads cleanly with no errors`, `… has dark theme + header + footer`, `… no horizontal overflow @ desktop|tablet|mobile`, `… logo image resolves`.
- **Site build**: `npm run build` wrote 141 files with no errors; both edited posts render with the corrected code blocks and editor's notes (verified by stripping tags from the generated HTML and grepping for `CreateUserResult`, `UserQuery`, `ValidationFailed`, `spawn {`, `await(profile)`, `perform Db.insert`).
- **Workflows**: both YAMLs parse via `yaml.safe_load`. On *this* PR the `changes` filter sees the workflow edits (outside `website/`), so `ci` + `rust` run in full and validate the new structure end-to-end; a future website-only PR will show `ci`/`rust` as skipped with only `website` running.
- **Extension**: `npm run lint` (`tsc --noEmit`) and `npm run compile` (`tsc -b`) both pass.

> Note: a full local `make ci` could not complete here because `cargo-llvm-cov` (the coverage gate) is not installed in this environment; this branch changes no compiler (`crates/`) or runtime (`compiler/runtime/`) source, and GitHub CI runs the authoritative full suite.
