### PR TITLE
ci(release): make web compiler deploy non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,5 +517,9 @@ jobs:
   deploy-webcompiler:
     name: Deploy web compiler
     needs: [github-release]
+    # Non-blocking: the browser compiler on Fly.io is an optional add-on, not a
+    # release artifact. A Fly outage or an invalid/banned FLY_API_TOKEN must not
+    # mark the whole release (VSIX + binaries + site) as failed.
+    continue-on-error: true
     uses: ./.github/workflows/deploy-webcompiler.yml
     secrets: inherit


### PR DESCRIPTION
<!-- agent-pmo:74cf183 -->
## TLDR
The v0.2.1 release published everything (VSIX to Marketplace, binaries, GitHub Release, site) but was marked failed solely because the Fly.io web-compiler deploy failed on an invalid/banned `FLY_API_TOKEN`. Make that deploy non-blocking.

## Details
- `deploy-webcompiler`: add `continue-on-error: true`. The browser compiler on Fly.io is an optional add-on, not a release artifact; a Fly outage or banned token must not fail the release.
- No change to the artifact-producing jobs.

## How Do The Automated Tests Prove It Works?
`release.yml` runs only on a `v*` tag; validated by `actionlint` + YAML parse. Required CI checks confirm the rest of the repo is unaffected.