### PR TITLE
fix(release): repair startup_failure from invalid continue-on-error on a uses: job

### DIFF
--- a/.github/workflows/deploy-webcompiler.yml
+++ b/.github/workflows/deploy-webcompiler.yml
@@ -20,6 +20,9 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
+        # Optional add-on: a Fly outage or an invalid/banned FLY_API_TOKEN must
+        # not fail a release. The browser compiler is not a release artifact.
+        continue-on-error: true
         run: |
           flyctl deploy --remote-only --app osprey --config webcompiler/fly.toml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -518,8 +518,8 @@ jobs:
     name: Deploy web compiler
     needs: [github-release]
     # Non-blocking: the browser compiler on Fly.io is an optional add-on, not a
-    # release artifact. A Fly outage or an invalid/banned FLY_API_TOKEN must not
-    # mark the whole release (VSIX + binaries + site) as failed.
-    continue-on-error: true
+    # release artifact. The deploy step itself is `continue-on-error` inside
+    # deploy-webcompiler.yml (continue-on-error is not valid on a `uses:` job),
+    # so a Fly outage or invalid/banned FLY_API_TOKEN can't fail the release.
     uses: ./.github/workflows/deploy-webcompiler.yml
     secrets: inherit


### PR DESCRIPTION
<!-- agent-pmo:74cf183 -->
## TLDR
#144 added `continue-on-error` to the `deploy-webcompiler` job, which calls a reusable workflow (`uses:`). That key is invalid on a `uses:` job, so `release.yml` failed to start (startup_failure, 0 jobs) on every trigger. Move the tolerance to the flyctl step.

## Details
- `release.yml`: remove `continue-on-error` from the `deploy-webcompiler` job.
- `deploy-webcompiler.yml`: add `continue-on-error: true` to the `Deploy to Fly.io` step. The reusable job then succeeds even if the Fly deploy fails (invalid/banned token), keeping the release green without breaking workflow validity.

## How Do The Automated Tests Prove It Works?
`actionlint` + YAML parse pass; the proof is the re-tagged release run starting (no startup_failure) and ending green with the Fly deploy tolerated.