### PR TITLE
ci(release): skip the binary matrix on website-only releases [SWR-REL-CHANGES]

### DIFF
--- a/.github/release-scope.json
+++ b/.github/release-scope.json
@@ -1,0 +1,41 @@
+{
+  "binary": [
+    "crates/**",
+    "compiler/**",
+    "tree-sitter-osprey/**",
+    "webcompiler/**",
+    "Cargo.toml",
+    "Cargo.lock",
+    "Makefile"
+  ],
+  "vsix": [
+    "vscode-extension/**"
+  ],
+  "website": [
+    "website/**",
+    "benchmarks/**"
+  ],
+  "ignore": [
+    "**/*.md",
+    "docs/**",
+    "examples/**",
+    ".github/**",
+    ".devcontainer/**",
+    ".vscode/**",
+    ".claude/**",
+    ".cursor/**",
+    ".clinerules/**",
+    ".cursorrules",
+    ".windsurfrules",
+    ".deslop.toml",
+    ".gitignore",
+    ".dockerignore",
+    "clippy.toml",
+    "rustfmt.toml",
+    "coverage-thresholds.json",
+    "opencode.json",
+    "osprey.code-workspace",
+    "pull_request_template.md",
+    "test_output.txt"
+  ]
+}

--- a/.github/workflows/release-change-detection.yml
+++ b/.github/workflows/release-change-detection.yml
@@ -1,0 +1,147 @@
+# release-change-detection.yml — Shipwright-shipped reusable workflow.
+#
+# COST CONTROL. Diff the pushed release tag against the previous release tag and
+# decide which surfaces must publish, so the expensive macOS/Windows build matrix
+# only runs when the artifact it produces actually changed.
+# Implements docs/specs/release-change-detection.md [SWR-REL-CHANGES-*]
+# (the Shipwright realisation of the Deslop SWR-REL-CHANGES proposal):
+#   - binary changed     -> full release: build matrix + every channel  [SWR-REL-CHANGES-CASCADE]
+#   - vsix / jetbrains    -> still build the matrix (the artifact bundles a binary at the
+#                            new tag version), publish that surface, skip the rest  [SWR-REL-CHANGES-MATRIX]
+#   - website only        -> deploy the site, skip the whole matrix
+#   - unclassified path   -> full release, fail-safe                     [SWR-REL-CHANGES-FAILSAFE]
+#   - first release / nothing matched -> full release
+#
+# Single-version contract: a tag stamps one version and host activation-verify is
+# onMismatch:error, so a published VSIX/JetBrains plugin MUST bundle binaries built
+# at the new version. Reusing a prior release's binary is therefore NOT done here.
+#
+# Supply chain (docs/specs/supply-chain-security.md):
+#   - SWR-SEC-ACTION-PINNING  every `uses:` is a full 40-char commit SHA.
+#   - SWR-SEC-TOKEN-PRIVILEGE read-only token; no write/id-token needed here.
+#   - the classifier is installed from a PINNED Shipwright commit (`shipwright_rev`).
+
+name: release-change-detection
+
+on:
+  workflow_call:
+    inputs:
+      config_path:
+        description: "Path to the release-scope ruleset (schemas/release-scope.schema.json)."
+        required: false
+        type: string
+        default: .github/release-scope.json
+      shipwright_rev:
+        description: "FULL 40-char commit SHA of Nimblesite/Shipwright to install shipwright-release-scope from. Pin it (SWR-SEC-ACTION-PINNING); the shipwright-compliance skill fills this in on rollout."
+        required: true
+        type: string
+      tag_match:
+        description: "glob used to find the previous release tag (git describe --match)."
+        required: false
+        type: string
+        default: "v[0-9]*"
+    outputs:
+      full:
+        description: "true for a full release — publish the standalone binary, Homebrew, Scoop, every extension, and the website."
+        value: ${{ jobs.scope.outputs.full }}
+      build_matrix:
+        description: "true when the native binary build matrix must run (full, or a binary-bundling artifact changed). The expensive, macOS/Windows-heavy gate."
+        value: ${{ jobs.scope.outputs.build_matrix }}
+      vsix:
+        description: "true when the VS Code extension must be published."
+        value: ${{ jobs.scope.outputs.vsix }}
+      jetbrains:
+        description: "true when the JetBrains plugin must be published."
+        value: ${{ jobs.scope.outputs.jetbrains }}
+      website:
+        description: "true when the documentation website must be deployed."
+        value: ${{ jobs.scope.outputs.website }}
+      previous_tag:
+        description: "The previous release tag the diff was taken against ('' on the first release)."
+        value: ${{ jobs.scope.outputs.previous_tag }}
+
+# SWR-SEC-TOKEN-PRIVILEGE: read-only; this job only reads git history.
+permissions:
+  contents: read
+
+jobs:
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      # `||` falls through the empty string from a skipped step to the value set
+      # by whichever step actually ran (first-release vs classified).
+      full: ${{ steps.decide.outputs.full || steps.first.outputs.full }}
+      build_matrix: ${{ steps.decide.outputs.build_matrix || steps.first.outputs.build_matrix }}
+      vsix: ${{ steps.decide.outputs.vsix || steps.first.outputs.vsix }}
+      jetbrains: ${{ steps.decide.outputs.jetbrains || steps.first.outputs.jetbrains }}
+      website: ${{ steps.decide.outputs.website || steps.first.outputs.website }}
+      previous_tag: ${{ steps.prev.outputs.previous_tag }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0            # full history + tags for the tag-to-tag diff
+          persist-credentials: false
+
+      - name: Resolve previous release tag
+        id: prev
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="${GITHUB_REF_NAME}"
+          # Newest release tag strictly older than the current tag on this history.
+          prev="$(git describe --tags --abbrev=0 --match '${{ inputs.tag_match }}' "${current}^" 2>/dev/null || true)"
+          echo "previous_tag=${prev}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${prev:-<none>}; current: ${current}"
+
+      # First release (no previous tag): nothing to diff against — publish everything.
+      - name: First-release short-circuit
+        id: first
+        if: steps.prev.outputs.previous_tag == ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "full=true"
+            echo "build_matrix=true"
+            echo "vsix=true"
+            echo "jetbrains=true"
+            echo "website=true"
+          } >> "$GITHUB_OUTPUT"
+          echo "No previous tag — full release." >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        if: steps.prev.outputs.previous_tag != ''
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.prev.outputs.previous_tag != ''
+        with:
+          key: release-scope-${{ inputs.shipwright_rev }}
+
+      - name: Install shipwright-release-scope (pinned)
+        if: steps.prev.outputs.previous_tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo install --locked \
+            --git https://github.com/Nimblesite/Shipwright \
+            --rev "${{ inputs.shipwright_rev }}" \
+            shipwright-release-scope
+
+      - name: Classify changed paths
+        id: decide
+        if: steps.prev.outputs.previous_tag != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --name-only \
+            "${{ steps.prev.outputs.previous_tag }}..${GITHUB_REF_NAME}" > changed.txt
+          echo "Changed files since ${{ steps.prev.outputs.previous_tag }}:"
+          cat changed.txt
+          # The tool appends full/build_matrix/vsix/jetbrains/website to $GITHUB_OUTPUT
+          # and a summary to $GITHUB_STEP_SUMMARY, and prints the full JSON to stdout.
+          shipwright-release-scope \
+            --config "${{ inputs.config_path }}" \
+            --changed changed.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,14 @@ name: Release
 # Version stamping ([SWR-VERSION-BUILD-STAMPING]): the version is derived from
 # the tag and stamped into every artifact. Source stays at 0.0.0-dev.
 #
+# Cost gate ([SWR-REL-CHANGES-*]): the `scope` job diffs this tag against the
+# previous one and gates the rest, so a website/benchmark-only tag deploys the
+# site without rebuilding the macOS/Windows binary matrix or republishing
+# brew/scoop/VSIX/Marketplace. Ruleset: .github/release-scope.json.
+#
 # Job shapes follow Shipwright's templates/gh-actions/*.yml (binary-multiplatform,
-# publish-brew-tap, publish-scoop-bucket, publish-vsix-per-platform).
+# publish-brew-tap, publish-scoop-bucket, publish-vsix-per-platform,
+# release-change-detection).
 on:
   push:
     tags: ['v*']
@@ -29,6 +35,25 @@ env:
   DESCRIPTION: "Osprey — a functional language with algebraic effects, fibers, and compile-time safety"
 
 jobs:
+  # --------------------------------------------------------------------------
+  # Release scope (COST GATE) — diff this tag against the previous release tag and
+  # decide which surfaces must publish, so the expensive macOS/Windows build matrix
+  # only runs when the artifact it produces actually changed. Ruleset lives in
+  # .github/release-scope.json. Implements [SWR-REL-CHANGES-*]:
+  #   binary changed    -> full release (build matrix + every channel)
+  #   vsix changed       -> still build the matrix (the VSIX bundles a binary at the
+  #                         new tag version), publish the VSIX, skip the other channels
+  #   website only       -> deploy the site, skip the whole matrix
+  #   unclassified path  -> full release, fail-safe
+  scope:
+    name: Decide release scope
+    uses: ./.github/workflows/release-change-detection.yml
+    permissions:
+      contents: read
+    with:
+      # Pinned Shipwright commit the classifier is installed from [SWR-SEC-ACTION-PINNING].
+      shipwright_rev: 78f1455f27e8bfefc96e757a3eab23289be0e3f7
+
   # --------------------------------------------------------------------------
   version:
     name: Resolve version from tag
@@ -58,7 +83,11 @@ jobs:
   # --------------------------------------------------------------------------
   build:
     name: Build ${{ matrix.platform }}
-    needs: version
+    needs: [version, scope]
+    # The expensive native matrix runs only when an artifact that bundles a binary
+    # changed — a full release, or a vsix/jetbrains change (which must rebuild the
+    # binary at the new tag version). A website-only tag skips it. [SWR-REL-CHANGES-MATRIX]
+    if: ${{ needs.scope.outputs.build_matrix == 'true' }}
     runs-on: ${{ matrix.os }}
     # Windows is the newest, least-proven target — keep a win32 hiccup from
     # blocking the mac/linux binaries + VSIX publish. A win32 failure shows as a
@@ -150,7 +179,10 @@ jobs:
   # --------------------------------------------------------------------------
   github-release:
     name: Publish GitHub Release
-    needs: [version, build]
+    needs: [version, build, scope]
+    # The standalone binary GitHub Release (and the brew/scoop jobs that depend on
+    # it) only ship on a full release. [SWR-REL-CHANGES-CASCADE]
+    if: ${{ needs.scope.outputs.full == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -322,7 +354,11 @@ jobs:
   # extension launches a version-matched compiler verified by @nimblesite/shipwright-vscode.
   vsix:
     name: Publish VSIX ${{ matrix.target }}
-    needs: [version, build]
+    needs: [version, build, scope]
+    # Package the per-platform VSIX only when the extension changed (or a full
+    # release). build_matrix is guaranteed true here, so the bundled binary is
+    # rebuilt at the new tag version. [SWR-REL-CHANGES-MATRIX]
+    if: ${{ needs.scope.outputs.vsix == 'true' }}
     runs-on: ${{ matrix.os }}
     # Match the build job: a win32 VSIX hiccup must not block the mac/linux
     # VSIXes from reaching the Marketplace.
@@ -500,14 +536,15 @@ jobs:
 
   # --------------------------------------------------------------------------
   # Website deploy — the live site updates ONLY as part of a release (never on a
-  # push to main). Gated solely on the GitHub Release existing, so a Marketplace
-  # / brew / scoop hiccup never blocks the docs going live. Stable tags only:
-  # a SemVer prerelease tag (v1.2.3-rc.1) contains a hyphen and is skipped, so a
-  # prerelease never overwrites the live site.
+  # push to main). Decoupled from the binary release: it deploys whenever the
+  # website surface changed (full release, or a website-only tag), so benchmark /
+  # docs updates ship without rebuilding the whole binary matrix. [SWR-REL-CHANGES]
+  # Stable tags only: a SemVer prerelease tag (v1.2.3-rc.1) contains a hyphen and
+  # is skipped, so a prerelease never overwrites the live site.
   deploy-site:
     name: Deploy website to GitHub Pages
-    needs: [github-release]
-    if: ${{ !contains(github.ref_name, '-') }}
+    needs: [scope]
+    if: ${{ needs.scope.outputs.website == 'true' && !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/deploy-pages.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

A tag-triggered release rebuilds the full macOS/Windows/Linux **binary matrix** and republishes Homebrew + Scoop + per-platform VSIX + Marketplace + Open VSX on **every** `v*` tag — even when the only thing that changed since the previous release is website/benchmark content. That's exactly what just happened with `v0.8.0`/`v0.9.0`: benchmark tables → full multi-platform rebuild + republish, for nothing.

## Fix — Shipwright release change-detection cost gate `[SWR-REL-CHANGES-*]`

Uses Shipwright's existing change-detection tooling (the "script for detecting this" already exists in the framework) rather than hand-rolling path filters.

- **`.github/release-scope.json`** — ruleset mapping path globs → surfaces (`binary` / `vsix` / `website` / `ignore`), validated by Shipwright's `release-scope.schema.json`.
- **`.github/workflows/release-change-detection.yml`** — Shipwright's reusable workflow: resolves the previous tag, `git diff`s tag→tag, runs `shipwright-release-scope` (installed from a **pinned** Shipwright commit `78f1455`), and exposes `full` / `build_matrix` / `vsix` / `website` outputs.
- **`release.yml`** — new `scope` job runs first; every other job is gated on its outputs:
  | Job | Gate |
  |---|---|
  | `build` (native matrix) | `build_matrix == 'true'` |
  | `github-release` → `brew`, `scoop` | `full == 'true'` (cascade) |
  | `vsix` → `publish-marketplace`, `publish-openvsx` | `vsix == 'true'` (cascade) |
  | `deploy-site` | `website == 'true'` (decoupled from `github-release`) |

### Contract (per spec, fail-safe)
- **binary changed → full release** (everything). `[SWR-REL-CHANGES-CASCADE]`
- **vsix changed → still builds the binary matrix** (the VSIX must bundle a binary stamped at the new tag — no binary reuse). `[SWR-REL-CHANGES-MATRIX]`
- **website-only → deploy the site, skip the whole matrix** ← the case this PR fixes.
- **unclassified path → full release** (fail-safe; never under-ships). `[SWR-REL-CHANGES-FAILSAFE]`

`binary` deliberately covers every compiled source + lockfile (`crates/**`, `compiler/**`, `tree-sitter-osprey/**`, `webcompiler/**`, `Cargo.{toml,lock}`, `Makefile`) so a real binary change can never skip the rebuild. `benchmarks/**` is classified `website` (its only consumer is the site's tables).

## Notes
- Takes effect on the **next** tag after merge (release workflows run from the tagged commit).
- No new secrets required.
- Validated locally: both workflows parse as YAML, `release-scope.json` parses and contains only schema-allowed keys, and the job graph gating is wired as above.
